### PR TITLE
changes to get git peeves in sync for v.2.32 (removing rescue_region …

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -937,3 +937,5 @@ our $Peeves_version = "2.30.3"; #  DC-917: GA35 changes: excluding incomplete_tr
 our $Peeves_version = "2.30.4"; #  DC-917: GA35 changes: adding between field cross-checks
 # 6.12.2021
 our $Peeves_version = "2.31"; #  GA8: adding warning for most 'in vitro construct - X' child terms - most cases should now use 'in vitro construct' parent instead (related to DC-917, adding curation of GA35)
+# 8.12.2021
+our $Peeves_version = "2.32"; #  GA35: removing 'rescue_region' as allowed term (we think it would be better to derive this from appropriate data if users want this information) (related to DC-917)

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.31"; #  GA8: adding warning for most 'in vitro construct - X' child terms - most cases should now use 'in vitro construct' parent instead (related to DC-917, adding curation of GA35)
+our $Peeves_version = "2.32"; #  GA35: removing 'rescue_region' as allowed term (we think it would be better to derive this from appropriate data if users want this information) (related to DC-917)
 
 =head2 Version
 

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -935,7 +935,7 @@ my $dv_short_qualifiers = {
 
 # adding additional SO terms allowed for GA35 that are not in the two main 'variant' branches used
 
-	my @additional_GA35 = ('wild_type', 'cDNA', 'genomic_DNA', 'rescue_region', 'polymorphic_sequence_variant');
+	my @additional_GA35 = ('wild_type', 'cDNA', 'genomic_DNA', 'polymorphic_sequence_variant');
 
 	foreach my $term (@additional_GA35) {
 

--- a/records2test/GA35/gm2.edit
+++ b/records2test/GA35/gm2.edit
@@ -62,7 +62,6 @@
 ! GA2b.  Allele name(s) used in reference                       *V :
 ! GA35.  Transgenic product class [CV]     :wild_type
 genomic_DNA
-rescue_region
 ! GA10a. Associated construct                                *I :
 ! GA10b. Construct symbol(s) used in reference               *L :
 ! GA10c. Associated insertion - G1a is outwith insert      *G :

--- a/records2test/GA35/gm3.edit
+++ b/records2test/GA35/gm3.edit
@@ -33,6 +33,7 @@
 deficient_inversion
 in vitro construct - regulatory fusion
 not a valid SO term
+rescue_region
 ! GA10a. Associated construct                                *I :
 ! GA10b. Construct symbol(s) used in reference               *L :
 ! GA10c. Associated insertion - G1a is outwith insert      *G :


### PR DESCRIPTION
…from allowing values for GA35, related to DC_917)