### PR TITLE
v.2.35: add chemical proforma to list of those not checked by Peeves …

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -943,3 +943,5 @@ our $Peeves_version = "2.32"; #  GA35: removing 'rescue_region' as allowed term 
 our $Peeves_version = "2.33"; #  DC-998: improved checks for GG4
 # 25.5.2022
 our $Peeves_version = "2.34"; #  making genome release number field compulsory when related seq. coord field filled in
+# 27.5.2022
+our $Peeves_version = "2.35"; #  add chemical proforma to list of those not checked by Peeves (DC-1012)

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.34"; #  making genome release number field compulsory when related seq. coord field filled in
+our $Peeves_version = "2.35"; #  add chemical proforma to list of those not checked by Peeves (DC-1012)
 
 =head2 Version
 
@@ -913,6 +913,7 @@ my %despatch_table = ('MULTIPUBLICATION'                => \&do_multipub_proform
 my %not_checked = (
 
 	'DISEASE IMPLICATED VARIANT' => '1',
+	'CHEMICAL' => '1',
 
 );
 


### PR DESCRIPTION
…(DC-1012)
This change means a nicer warning is printed when chemical proforma is run though peeves - instead of incorrectly saying is unknown proforma type, it reminds the curator that this kind of proforma needs to go through the python parser for checking (like for DIV proforma).
I didn't make test records as I ran it over fb_2022_03_EP9 archive instead.