### PR TITLE
v.2.38: adding chemical flag (DC-1027) plus removing temporary hack f…

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -948,3 +948,5 @@ our $Peeves_version = "2.35"; #  add chemical proforma to list of those not chec
 # 29.7.2022
 our $Peeves_version = "2.36"; #  DC-1018: remove unecessary false positive from pheno/GI CV fields
 our $Peeves_version = "2.37"; #  DC-1020: add warning for comma in with pheno/GI CV lines
+# 31.8.2022
+our $Peeves_version = "2.38"; #  DC-1027: adding chemical flag

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.37"; #  DC-1020: add warning for comma in with pheno/GI CV lines
+our $Peeves_version = "2.38"; #  DC-1027: adding chemical flag
 
 =head2 Version
 

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -1128,13 +1128,6 @@ my $dv_short_qualifiers = {
 
     set_symbol ('no_flag',           'P41_flag', 'solo');
     set_symbol ('wt_exp',            'P41_flag', 'multi');
-
-#Temporary end-around to prevent error warnings for 'pert_exp' in user records
-# until checkbox can be removed from FTYP tool	
-	if ($Peeves_config{'Where_running'} eq 'IU') {
-		    set_symbol ('pert_exp',          'P41_flag', 'multi');
-
-	}
     set_symbol ('neur_exp',          'P41_flag', 'multi');
 #    set_symbol ('marker',            'P41_flag', 'multi');
     set_symbol ('gene_model',        'P41_flag', 'multi');
@@ -1149,6 +1142,7 @@ my $dv_short_qualifiers = {
     set_symbol ('cell_line',           'P41_flag', 'multi');
     set_symbol ('cell_line(commercial)',           'P41_flag', 'multi');
     set_symbol ('cell_line(stable)',           'P41_flag', 'multi');
+    set_symbol ('chemical',           'P41_flag', 'multi');
 
 #    set_symbol ('cell_cult',         'P41_flag', 1);
 #    set_symbol ('trans_assay',       'P41_flag', 1);


### PR DESCRIPTION
…or pert_exp now FTYP updated

this is adding the chemical flag for harvcur (DC-1027), plus I removed a no-longer needed hack for pert_exp