### PR TITLE
Changes to get v.2.41 into git production peeves

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -954,3 +954,5 @@ our $Peeves_version = "2.38"; #  DC-1027: adding chemical flag
 our $Peeves_version = "2.39"; #  D0C-210: adding new allowed value for SP5
 # 17.11.2022
 our $Peeves_version = "2.40"; #  removing checking for obsolete seqfeat fields
+# 10.5.2023
+our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate for sequence targeting reagents (RNAi, sgRNA, miRNA) can be added in this field.

--- a/doc/specs/allele/GA35.txt
+++ b/doc/specs/allele/GA35.txt
@@ -30,7 +30,7 @@ No (implemented)
 Checks within field:
 
 
-* sub 'validate_cvterm_field' checks that this is a valid SO term from the expected branches ('structural_variant', 'functional_effect_variant' and 'additional_GA35' terms that are not in the first two branches, but are specified in the @additional_GA35 array in symtab.pl).
+* sub 'validate_cvterm_field' checks that this is a valid SO term from the expected branches: 'SO:structural_variant', 'SO:functional_effect_variant', 'SO:oligo', 'additional_targeting_GA35', and 'additional_GA35'. The latter two are SO terms not in the first three branches, and are specified in symtab.pl. 'oligo' plus 'additional_targeting_GA35' are the terms expected for transgenes that target a gene of interest using complementary nucleotide sequence and having these separate from 'additional_GA35' will allow for more flexibility when checking GA35 against GA30c once we can put seqfeat in GA30c.
 
 * sub 'validate_cvterm_field' also warns if a valid SO term from the 'translational_product_structure_variant branch' is used and suggests using a term from the 'coding_sequence_variant' branch instead.
 
@@ -53,7 +53,7 @@ Checks between fields:
 
   * if the parent gene of the allele is NOT usually used as an experimental tool
 
-     - Peeves warns if GA35 is empty (unless it has 'in vitro construct - RNAi' in the mutagen field - this is a temporary hack until we can use experimental tool fields to describe this kind of targeting construct)
+     - Peeves warns if GA35 is empty.
 
 
 
@@ -63,10 +63,6 @@ Checks between fields:
 
 ### Comments:
 
-The constraint using 'in vitro construct - RNAi' should be removed when we implement using experimental tool fields to describe targeting constructs such as RNAi, sgRNA lines. (JIRA DC-910).
-
-Have not put in a test for GA35 being filled in for a targeting construct, because it will trip the general 'not valid in this field' check as the relevant SO terms are not in the allowed set for GA35.
-
 
 ### Status:
 
@@ -74,4 +70,4 @@ Have not put in a test for GA35 being filled in for a targeting construct, becau
 
 ### Updated:
 
-gm211123.
+gm230510.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.40"; #  removing checking for obsolete seqfeat fields
+our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate for sequence targeting reagents (RNAi, sgRNA, miRNA) can be added in this field.
 
 =head2 Version
 

--- a/production/allele.pl
+++ b/production/allele.pl
@@ -857,18 +857,8 @@ if ($hash_entries) {
 
 					unless (defined $common_tool_uses && (scalar @{$common_tool_uses} > 0)) {
 
-						my $mutagen_switch = 0;
-						foreach my $datum (split (/\n/, $GA8_list[$i])) {
 
-							if ($datum eq 'in vitro construct - RNAi') {
-								$mutagen_switch++;
-							}
-
-						}
-
-						unless ($mutagen_switch) {
-							report ($file, "WARNING: %s is usually filled in for a new '%s' allele of a 'non-experimental tool' parent gene, did you forget to fill it in ? NOTE: if this is a targeting construct that contains complementary nucleotide sequence of a gene of interest (RNAi, sgRNA, antisense etc.) then this message is a false-positive\n!%s", 'GA35', $allele_type, $proforma_fields{'GA1a'});
-						}
+						report ($file, "WARNING: %s is usually filled in for a new '%s' allele of a 'non-experimental tool' parent gene, did you forget to fill it in ?\n!%s", 'GA35', $allele_type, $proforma_fields{'GA1a'});
 					}
 
 				}

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -802,6 +802,7 @@ my $dv_short_qualifiers = {
 		'structural_variant' => '1',
 		'translational_product_structure_variant' => '1',
 		'incomplete_transcript_variant' => '1',
+		'oligo' => '1',
 
 	};
 
@@ -933,7 +934,20 @@ my $dv_short_qualifiers = {
 	my @reagent_collection_protocol_types = ('FBcv:assay_attribute', 'FBcv:biosample_attribute');
 	set_symbol ('reagent_collection_protocol_types', 'allowed_type_list', \@reagent_collection_protocol_types);
 
-# adding additional SO terms allowed for GA35 that are not in the two main 'variant' branches used
+# adding SO terms applicable for transgenes that target a gene of interest using complementary nucleotide sequence that are not in the SO:oligo branch. Adding them as their own type to give more flexibility in error messages, particularly for cross-checks between GA35/GA30c.
+
+	my @additional_targeting_GA35 = ('antisense', 'miRNA');
+
+	foreach my $term (@additional_targeting_GA35) {
+
+		set_symbol ($term, 'additional_targeting_GA35', '1');
+
+		valid_symbol ($term, 'SO:default') or print "MAJOR PEEVES ERROR in basic ontology processing: the '$term' term listed in Peeves as an additional valid value for GA35 is no longer a valid SO term, Peeves will need altering to cope (probably by replacing this obsolete term with a new valid one).\n\n";
+
+	}
+
+# adding additional SO terms allowed for GA35 that are not in either the two main 'variant' branches or those used for transgenes that target a gene of interest using complementary nucleotide sequence (so not in SO:oligo or 'additional_targeting_GA35')
+
 
 	my @additional_GA35 = ('wild_type', 'cDNA', 'genomic_DNA', 'polymorphic_sequence_variant');
 
@@ -944,7 +958,6 @@ my $dv_short_qualifiers = {
 		valid_symbol ($term, 'SO:default') or print "MAJOR PEEVES ERROR in basic ontology processing: the '$term' term listed in Peeves as an additional valid value for GA35 is no longer a valid SO term, Peeves will need altering to cope (probably by replacing this obsolete term with a new valid one).\n\n";
 
 	}
-
 
 
 #  Then various classes of essentially static symbols.  This code looks ugly but the lists have to live

--- a/production/tools.pl
+++ b/production/tools.pl
@@ -3703,7 +3703,7 @@ sub validate_cvterm_field {
 		'GG4' => ['FBcv:group_descriptor'],
 		'A4' => ['FBcv:origin_of_mutation'],
 		'GA4' => ['FBcv:allele_class'],
-		'GA35' => ['SO:structural_variant', 'SO:functional_effect_variant', 'additional_GA35'],
+		'GA35' => ['SO:structural_variant', 'SO:functional_effect_variant', 'additional_GA35', 'SO:oligo', 'additional_targeting_GA35'],
 		'GA8' => ['FBcv:origin_of_mutation'],
 		'G34' => ['antibody'],
 		'MA8' => ['insertion_phenotype'],

--- a/records2test/GA35/gm7.thin
+++ b/records2test/GA35/gm7.thin
@@ -1,0 +1,117 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0254875
+! P2.   Parent multipub abbreviation               *w :BMC Biol.
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :??GA35 filled in for targeting reagents??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :hh
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :hh[somenewthing]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :n
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :NEW:P{UAS-hh.new}
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :in vitro construct - RNAi
+! GA36.  Allele/construct represents a human disease-implicated variant? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :RNAi_reagent
+! GA30e. Regulatory region(s) present (symbol)  :UAS
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :free text.
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :??should pass??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :hh[another.new.UAS]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :n
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :NEW:P{anotherconstruct}
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :in vitro construct
+! GA36.  Allele/construct represents a human disease-implicated variant? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :miRNA
+sgRNA
+! GA30e. Regulatory region(s) present (symbol)  :dpp
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :more free text.
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :GAL4
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :??terms in GA35 should pass, but cross checks with GA30c should complain at least until can use seq feat in GA30c??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
these changes are small tweaks to what is allowed in GA35 field.

we’ve decided that the type of sequence targeting reagents using SO terms such as RNAi_reagent or sgRNA will be put in the GA35 transgenic product class field (so that this info is together with the type information for other types of transgene, e.g. wild_type, missense_variant), so these changes allow that.

(there is no specific JIRA ticket, hence non-standard name of branch)