### PR TITLE
v2.42: Tweaks to GA35 checks: removing miRNA from allowed values (rel…

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -956,3 +956,5 @@ our $Peeves_version = "2.39"; #  D0C-210: adding new allowed value for SP5
 our $Peeves_version = "2.40"; #  removing checking for obsolete seqfeat fields
 # 10.5.2023
 our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate for sequence targeting reagents (RNAi, sgRNA, miRNA) can be added in this field.
+# 17.5.2023
+our $Peeves_version = "2.42"; #  Tweaks to GA35 checks: removing miRNA from allowed values (related to comment in DB-867).

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate for sequence targeting reagents (RNAi, sgRNA, miRNA) can be added in this field.
+our $Peeves_version = "2.42"; #  Tweaks to GA35 checks: removing miRNA from allowed values (related to comment in DB-867).
 
 =head2 Version
 

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -936,7 +936,7 @@ my $dv_short_qualifiers = {
 
 # adding SO terms applicable for transgenes that target a gene of interest using complementary nucleotide sequence that are not in the SO:oligo branch. Adding them as their own type to give more flexibility in error messages, particularly for cross-checks between GA35/GA30c.
 
-	my @additional_targeting_GA35 = ('antisense', 'miRNA');
+	my @additional_targeting_GA35 = ('antisense');
 
 	foreach my $term (@additional_targeting_GA35) {
 


### PR DESCRIPTION
…ated to comment in DB-867).

Changes are just to remove 'miRNA' from allowed values in GA35 as it turned out that is not appropriate (as per comment on DB-867)