### PR TITLE
v.2.43: DC-1041: allow stamps_with_ids in TC9 field'

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -958,3 +958,5 @@ our $Peeves_version = "2.40"; #  removing checking for obsolete seqfeat fields
 our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate for sequence targeting reagents (RNAi, sgRNA, miRNA) can be added in this field.
 # 17.5.2023
 our $Peeves_version = "2.42"; #  Tweaks to GA35 checks: removing miRNA from allowed values (related to comment in DB-867).
+# 29.6.2023
+our $Peeves_version = "2.43"; #  DC-1041: allow stamps_with_ids in TC9 field.

--- a/doc/specs/cellline/TC9.txt
+++ b/doc/specs/cellline/TC9.txt
@@ -25,7 +25,7 @@ No (implemented)
 
 ### Checks:
 
-Checks within field: check_stamped_free_text
+Checks within field: check_stamped_free_text_with_ids
 
 ### Related fields:
 
@@ -41,4 +41,4 @@ Checks within field: check_stamped_free_text
 
 ### Updated:
 
-gm170127.
+gm230629.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.42"; #  Tweaks to GA35 checks: removing miRNA from allowed values (related to comment in DB-867).
+our $Peeves_version = "2.43"; #  DC-1041: allow stamps_with_ids in TC9 field.
 
 =head2 Version
 
@@ -855,7 +855,7 @@ our %field_specific_checks = (
 	'TC5c' => \&validate_cvterm_field,
 	'TC5d' => \&check_stamped_free_text,
 	'TC8' => \&check_valid_symbol_field,
-	'TC9' => \&check_stamped_free_text,
+	'TC9' => \&check_stamped_free_text_with_ids,
 	'TC10' => \&no_stamps,
 
 # experimental tool

--- a/records2test/DC-1041/gm1.edit
+++ b/records2test/DC-1041/gm1.edit
@@ -1,0 +1,82 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0256520
+! P2.   Parent multipub abbreviation               *w :EMBO J.
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc9000008
+! TC1a. Cell line symbol to use in database  :S2-Invitrogen
+! TC1b. Symbol used in paper/source (free text) :
+! TC9.  Comment(s) (free text)       :Stable cell line generated: testing @S2-Invitrogen@, @dpp@ and @FBgn0001145:Gs2@.
+! TC10. Internal note(s) (free text) :??no errors
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :
+! TC1a. Cell line symbol to use in database  :new_cell_line
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :Dmel
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :testing @new_cell_line@ is OK.
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000156
+! TC1a. Cell line symbol to use in database  :CME-L1
+! TC1b. Symbol used in paper/source (free text) :
+! TC9.  Comment(s) (free text)       :testing mismatch @FBgn0287789:hh@.
+! TC10. Internal note(s) (free text) :??gene symbol id mismatch??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000218
+! TC1a. Cell line symbol to use in database  :S2-Mt-Fog-myc
+! TC1b. Symbol used in paper/source (free text) :
+! TC9.  Comment(s) (free text)       :testing id and symbol wrong way round @S2-Mt-Fog-myc:FBtc0000218@. The @en@ is OK and @this_is_invalid@.
+! TC10. Internal note(s) (free text) :??symbol and id are wrong way round??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
changes for DC-1041.
**Details as follows:**
1. new subroutine in tools.pl: **check_stamped_free_text_with_ids**

- this is a wrapper for existing `check_stamps_with_ids` subroutine (wrapper makes it easy to fit in to the standard Peeves field checking template that uses process_field_data + %field_specific_checks to do common sanity checks and specify specific checks for field, while keeping `check_stamps_with_ids` free for use in checking part of F9 field)
- Peeves now specifies that TC9 should use `check_stamped_free_text_with_ids`
- this means that TC9 can now use simple `@@` and also `@FBid:symbol@` format - if `@FBid:symbol@` format is used, Peeves checks that the FBid and symbol pair match and warns if not.

2. changes to existing **check_stamps_with_ids** subroutine

- added an additional check to this subroutine so that if curator/script gets FBid and symbol backwards, i.e. writes `@symbol:FBid@` by mistake, they get a warning suggesting they swap them around _(I did this while making test records!)_

3. changes to `my @allowed_types` in both check_stamps and check_stamps_with_ids

- added FBtc as an allowed type in simple `@@` stamped free text (had not realised it was not already added)
-  changed order of allowed_types to try to put most likely symbol type first to try to speed up checks (although doens't really make much difference in testing)

4. added test records in records2test/DC-1041