### PR TITLE
Peeves changes for DC-852 and sub-tasks

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -960,3 +960,7 @@ our $Peeves_version = "2.41"; #  Tweaks to GA35 checks so that terms appropriate
 our $Peeves_version = "2.42"; #  Tweaks to GA35 checks: removing miRNA from allowed values (related to comment in DB-867).
 # 29.6.2023
 our $Peeves_version = "2.43"; #  DC-1041: allow stamps_with_ids in TC9 field.
+# 10.7.2023
+our $Peeves_version = "2.44"; #  DC-1044: allow any FBtc ID with 7 digits in TC1j.
+our $Peeves_version = "2.45"; #  DC-1042: Accept > character as valid for cell line names in TC1a.
+our $Peeves_version = "2.46"; #  DC-1043: Fix FBtc valid symbol lookup to cope with symbols with superscripts/subscripts.

--- a/doc/specs/cellline/TC1j.txt
+++ b/doc/specs/cellline/TC1j.txt
@@ -29,7 +29,7 @@ Checks within field
 
 * The value in TC1j must *not* be a valid FBtc id (because TC1j is only supposed to be filled in the first time a cell-line entry goes into the database - I think) (sub validate_TC1j)
 
-* The value in TC1j must match the format FBtc9[0-9]{6}   (these ids start with 9)
+* The value in TC1j must match the format FBtc[0-9]{7}
 
 Checks between fields
 
@@ -52,4 +52,4 @@ Checks between fields
 
 ### Updated:
 
-gm170130
+gm230710.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.43"; #  DC-1041: allow stamps_with_ids in TC9 field.
+our $Peeves_version = "2.46"; #  DC-1043: Fix FBtc valid symbol lookup to cope with symbols with superscripts/subscripts.
 
 =head2 Version
 

--- a/production/cellline.pl
+++ b/production/cellline.pl
@@ -328,8 +328,8 @@ sub validate_TC1j {
 
 	foreach my $datum (keys %{$uniqued_data}) {
 
-		unless ($datum =~ m|^FBtc9[0-9]{6}$|) {
-			report ($file, "%s: '%s' is not the correct format for this field (it should be 'FBtc9nnnnnn' where 'n' is any number.", $code, $datum);
+		unless ($datum =~ m|^FBtc[0-9]{7}$|) {
+			report ($file, "%s: '%s' is not the correct format for this field (it should be 'FBtcnnnnnnn' where 'n' is any number.", $code, $datum);
 
 
 		}

--- a/production/tools.pl
+++ b/production/tools.pl
@@ -1494,7 +1494,7 @@ sub check_allowed_characters {
 # proformae for which the valid symbol does not include a species prefix, even if the
 # species isn't Dmel (species is defined by a separate field in the proforma).
 # No species prefix is included in the valid symbol for non-Dmel cell lines.
-		'TC1a' => 'a-zA-Z0-9:;&\[\]\()\'\.\+\-', # same as G1a with removal of \ and addition of +
+		'TC1a' => 'a-zA-Z0-9:;&>\[\]\()\'\.\+\-', # same as G1a with removal of \ and addition of +. Also added > (DC-1042)
 		'LC1a' => 'a-zA-Z0-9_:;&\[\]\()\'\.\+\-', # same as TC1a, plus _
 
 # proformae where probably won't include the species prefix in the symbol for non-Dmel

--- a/records2test/DC-1042/gm1.edit
+++ b/records2test/DC-1042/gm1.edit
@@ -1,0 +1,91 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :??testing allowed characters in TC1a??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :FBtc0999999
+! TC1a. Cell line symbol to use in database  :a-z0-9rewyuiewfgewifgewui[]!
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :Dmel
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :FBtc9999999
+! TC1a. Cell line symbol to use in database  :f7werek>123672186!
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :Dmel
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1043/gm1.edit
+++ b/records2test/DC-1043/gm1.edit
@@ -1,0 +1,91 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000015
+! TC1j. Use this for FB ID (FBtc ID) :
+! TC1a. Cell line symbol to use in database  :E-r[1]
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :E-E12[ts]-mal[1]
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :@FBtc0000015:E-r[1]@ should be ok in stamps, as should @FBtc0000095:ML-DmD14@.
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000014
+! TC1j. Use this for FB ID (FBtc ID) :
+! TC1a. Cell line symbol to use in database  :E-E12[ts]-mal[1]
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :@FBtc0000001:E-E12[ts]-mal[1]@ is a mis-match.
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1043/gm2.edit
+++ b/records2test/DC-1043/gm2.edit
@@ -1,0 +1,156 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :checking fix works in other fields that expect a valid FBtc symbol
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! DATASET/COLLECTION PROFORMA   Version 4.1   19 September 2017
+!
+! LC1f. Database ID for dataset  :FBlc0000718
+! LC1a. Symbol                   :VDRC-VT
+! LC1b. Symbol used in paper/source  :
+! LC1d. Nickname [for labels]        :
+! LC6g. Dataset title  :
+! LC6a. Description [free text]  :
+! LC2a. Type of dataset entity [CV term ; ID]  :
+! LC2b. Type of dataset data [CV term ; ID]    :
+! LC3. Dataset belongs_to this project  :
+! LC14a. Dataset assay/collection is assay_of this biosample  :
+! LC14b. Dataset result is analysis_of  :
+! LC14c. Dataset uses_reagent  :
+! LC14d. Dataset technical_reference_is  :
+! LC14e. Dataset biological_reference_is  :
+! LC14f. Dataset replaced_by  :
+! LC14g. Dataset genome_reference_is  :
+! LC14h. Reference FlyBase gene model annotation set [free text]  :
+! LC3a. Action - rename this dataset symbol    :
+! LC3b. Action - merge these datasets      :
+! LC3c. Action - delete dataset record [y/blank]   :
+! LC3d. Action - dissociate LC1f from FBrf [y/blank]  :
+! LC3e. Action - dissociate LC1f from this dataset  :
+! LC13a. Key GO term(s) - Cellular Component [CV term ; ID]  :
+! LC13b. Key GO term(s) - Molecular Function [CV term ; ID]  :
+! LC13c. Key GO term(s) - Biological Process [CV term ; ID]  :
+! LC13d. Key SO term(s) [CV term ; ID]  :
+! LC4a. Species of derivation [CV]  :
+! LC4i. Other species of interest [CV]  :
+! LC4h. Strain used [symbol]    :
+! LC4b. Strain used [free text]  :
+! LC4f. Genotype used [free text]  :
+! LC4g. Stage and tissue (<e>  <t>  <a>  <s>  <note>)  :
+! LC4j. Tissue of interest [CV term ; ID]   :
+! LC4k. Stage of interest [CV term ; ID]   :
+! LC4e. Cell line used [symbol]  :E-E12[ts]-mal[1]
+S2-DGRC
+! LC12a. Experimental entity [FBid]  :
+! LC12b. Type of experimental entity [CV]  :
+! LC12c. Action - delete the dataset-feature relationship specified in LC12a/LC12b (y/blank)  :
+! LC6d. Dataset/collection members stored in database [Y/N]  :
+! LC6e. Number of entities in dataset/collection [if LC6d is N]   :
+! LC6f. Comment on number of entities in dataset/collection [free text]  :
+! LC11m. Experimental protocol - dataset [CV term ; ID]  :
+! LC11j. Experimental protocol - data analysis is secondary analysis (y/blank)  :
+! LC11a. Experimental protocol, source isolation and prep [free text]  :
+! LC6b. Experimental protocol, dataset/collection preparation [free text]  :
+! LC11c. Experimental protocol, mode of assay [free text]  :
+! LC11e. Experimental protocol, data analysis [free text]  :
+! LC7a. Types of additional data available [free text]  :
+! LC7f. Associated files, archived at ftp site [SoftCV]  :
+! LC7c. Additional data at [database name]  :
+! LC99a. DataSet Accession Number [dbxref.accession]  :
+! LC99b. Database name [database name]  :
+! LC99c. DataSet title [free text]  :
+! LC99d. Action - dissociate accession in LC99a/LC99b from dataset in LC1f/LC1a? (y/blank)  :
+! LC8a. Created by [database name]        :
+! LC8c. Created by [free text]      :
+! LC8b. Available from [database name]    :
+! LC8d. Available from [free text]  :
+! LC9. Additional comments  :
+! LC9a. Structured table [SoftCV]  :
+! LC10. Internal notes      :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :FBtc0999997
+! TC1a. Cell line symbol to use in database  :making-new[super]symbol
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000007
+! TC1j. Use this for FB ID (FBtc ID) :
+! TC1a. Cell line symbol to use in database  :EH34A3
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :making-new[super]symboltypo
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :incorrect  symbol with superscripts in TC4
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1043/gm3.edit
+++ b/records2test/DC-1043/gm3.edit
@@ -1,0 +1,59 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :trying Fbtc renames involving superscripts !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000018
+! TC1j. Use this for FB ID (FBtc ID) :
+! TC1a. Cell line symbol to use in database  :new-for-E-r[36]
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :E-r[36]
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :this pair: @FBtc0000018:new-for-E-r[36]@ is now ok.
+This second pair is the old symbol @FBtc0000018:E-r[36]@ and should mismatch. checking works !
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1044/gm1.edit
+++ b/records2test/DC-1044/gm1.edit
@@ -1,0 +1,124 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :FBtc0000181
+! TC1j. Use this for FB ID (FBtc ID) :FBtc0000181
+! TC1a. Cell line symbol to use in database  :S2-DRSC
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :??this should make an error in cross-check with TC1f as not new line
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :FBtc9999999
+! TC1a. Cell line symbol to use in database  :brand_new_line_in_DGRC
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :??ok
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! CULTURED CELL LINE PROFORMA            Version 5:  Jul 02 2014
+!
+! TC1f. FB ID for cell line (FBtc ID or "new")  :new
+! TC1j. Use this for FB ID (FBtc ID) :FBtc0099999
+! TC1a. Cell line symbol to use in database  :brand_new_line_not_in_DGRC
+! TC1b. Symbol used in paper/source (free text) :
+! TC1c. Symbol synonym (free text)           :
+! TC1d. Species of source [CV]               :
+!
+! TC1e. Action - rename this cell line         :
+! TC1g. Action - merge these cell lines        :
+! TC1h. Action - delete cell line record ("y"/blank)   :
+! TC1i. Action - dissociate TC1f from FBrf ("y"/blank) :
+!
+! TC2a. Source strain (soft CV)            :
+! TC2b. Source genotype (components in FB) :
+! TC2c. Source cross  (components in FB)   :
+! TC2d. Tissue source  [CV]                :
+! TC2e. Developmental stage of source [CV] :
+!
+! TC3a. Lab of origin (free text) :
+! TC4a. Parental cell line (valid cell line symbol) :
+! TC4b. Derived from parental line by (CV) :
+!
+! TC5a. Integrated construct insertion (FBti) :
+! TC5b. Karotype (free text)      :
+! TC5c. Sex ("male" or "female")  :
+! TC5d. Basis for sex (free text) :
+!
+! TC8.  Member of dataset/collection [symbol] :
+! TC9.  Comment(s) (free text)       :
+! TC10. Internal note(s) (free text) :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
changes for sub-tasks are as follows:

DC-1042: Accept ">" character as valid for cell line names in TC1a.
 - change in `check_allowed_characters` subroutine in `production/tools.pl`

DC-1043: Fix lookup of valid cell line symbol having superscripts/subscripts (square brackets).
- this is the changes in `production/symtab.pl`


- I had to add code to use the &sgml2utf subroutine to get the symbol being tested into the correct superscript/subscript format (i.e. `<up></up>` style) for the synonym.sgml table (which is what the chado queries use to cope with sgml greek symbols). This copied code used previously for other FBid types.

- I also had to add code to convert the stored symbol (that curators see) back into the [] style format - this is the code that uses `&utf2sgml` - might seem somewhat paradoxical, but it was necessary when I tested (so that the recently added TC9 checks of @FBtc::symbol@ work correctly), and again matched code used previously for other FBid types. 


DC-1044: TC1j: Allow for any FBtc ID having 7 digits (digits do not always start with 9).

- this is the change in cellline.pl
