### PR TITLE
DC-1047: changes for new FBco (combination) feature type - v.2.47.1 t…

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -964,3 +964,13 @@ our $Peeves_version = "2.43"; #  DC-1041: allow stamps_with_ids in TC9 field.
 our $Peeves_version = "2.44"; #  DC-1044: allow any FBtc ID with 7 digits in TC1j.
 our $Peeves_version = "2.45"; #  DC-1042: Accept > character as valid for cell line names in TC1a.
 our $Peeves_version = "2.46"; #  DC-1043: Fix FBtc valid symbol lookup to cope with symbols with superscripts/subscripts.
+# 12.9.2023
+our $Peeves_version = "2.47"; #  DC-1047: Changes for FBco (hemidriver combinations)
+our $Peeves_version = "2.47.1"; #  DC-1047: Adding encoding conversions for INTERSECTION symbol and FBco type to symbol checking.
+our $Peeves_version = "2.47.2"; #  DC-1047: Adding FBco to type_gene_product subroutine.
+our $Peeves_version = "2.47.3"; #  Fixed bug in F1f (gene product merge) checking (uncovered by adding test record for FBco for DC-1047).
+our $Peeves_version = "2.47.4"; #  DC-1047: adding checks for FBco in F2 and F3 fields.
+# 13.9.2023
+our $Peeves_version = "2.47.5"; #  DC-1047: adding extra checks for new FBco symbols (check that each allele is a split system component, and that bits are in the correct order).
+# 15.9.2023
+our $Peeves_version = "2.47.6"; #  DC-1047: adding checks to warn if F11 fields filled in for FBco.

--- a/doc/specs/expression/F11.txt
+++ b/doc/specs/expression/F11.txt
@@ -33,6 +33,7 @@ Checks between fields:
 
 - if F11b is filled in, F11 must be filled in.
 
+- F11 should not be filled in for combinations (FBco).
 
 
 ### Related fields:
@@ -49,4 +50,4 @@ Checks between fields:
 
 ### Updated:
 
-gm160305.
+gm230915.

--- a/doc/specs/expression/F11a.txt
+++ b/doc/specs/expression/F11a.txt
@@ -31,6 +31,9 @@ Checks between fields:
 
 - if F11a is filled in, F11 must be filled in.
 
+- F11a should not be filled in for combinations (FBco).
+
+
 ### Related fields:
 
 
@@ -45,4 +48,4 @@ Checks between fields:
 
 ### Updated:
 
-gm160305
+gm230915

--- a/doc/specs/expression/F11b.txt
+++ b/doc/specs/expression/F11b.txt
@@ -31,6 +31,8 @@ Checks between fields:
 
 - if F11b is filled in, F11 must be filled in.
 
+- F11b should not be filled in for combinations (FBco).
+
 ### Related fields:
 
 
@@ -45,4 +47,4 @@ Checks between fields:
 
 ### Updated:
 
-gm160305
+gm230915

--- a/doc/specs/expression/F1a.txt
+++ b/doc/specs/expression/F1a.txt
@@ -25,7 +25,7 @@ No (implemented)
 
 Checks within field:
 
-  * sub validate_primary_proforma_field (see doc/specs/allele/GA1a.txt for details). Note, although the gene product identifier may contain a species prefix, species abbreviation checks are not carried out in validate_primary_proforma_field for this proformae as it can contain more than one type of object (FBtr or FBpp).  Any species abbreviation checking should thus be added to the format checking done at the end of the proforma using the 'type_gene_product' subroutine [note that this has not been added as of 2017.02.06].
+  * sub validate_primary_proforma_field (see doc/specs/allele/GA1a.txt for details). Note, although the gene product identifier may contain a species prefix, species abbreviation checks are not carried out in validate_primary_proforma_field for this proformae as it can contain more than one type of object (FBtr, FBpp or FBco). Any species abbreviation checking should thus be added to the format checking done at the end of the proforma using the 'type_gene_product' subroutine [note that this has not been added as of 2017.02.06].
 
 
 Checks within validate_primary_proforma_field:
@@ -49,17 +49,41 @@ Cross-checks with other fields (done after parsing of entire proforma):
        genesymbol-XP (FBpp)
        allelesymbolRA (FBtr)
        allelesymbolPA (FBpp)
+       allelesymbol&cap;allelesymbol (FBco) ** see note below **
     
-     * the 'genesymbol' or 'allelesymbol' portion of the symbol must be a valid FBgn or FBal (respectively) symbol in chado or generated in the record.
-     
-The following two checks are done at the end of proforma checking within expression.pl, rather than trying to add it to the 'cross_check_harv_style_symbol_rename_merge_fields' subroutine which is used for several different 'Harvard' style proformae:
+     * the 'genesymbol' or 'allelesymbol' portions of the symbol must be a valid FBgn or FBal (respectively) symbol in chado or generated in the record.
 
-* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f (i.e. either genesymbol-XR or allelesymbolRA for a FBtr id, either genesymbol-XP or allelesymbolPA for a FBpp id).
+     * the format checking for FBco allows 2 or more allele symbols joined by &cap;, so allelesymbol&cap;allelesymbol&cap;allelesymbol (etc.) is also allowed.
+     
+The following checks are done at the end of proforma checking within expression.pl, rather than trying to add it to the 'cross_check_harv_style_symbol_rename_merge_fields' subroutine which is used for several different 'Harvard' style proformae:
+
+* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f (e.g. either genesymbol-XR or allelesymbolRA for a FBtr id, either genesymbol-XP or allelesymbolPA for a FBpp id).
 
 * If gene products are being merged:
 
-  * checks that the FBids in F1c (merge field) are all of one type (i.e. FBtr or FBpp) and prints an error message if not.
+  * checks that the FBids in F1c (merge field) are all of one type (i.e. FBtr, FBpp or FBco) and prints an error message if not.
   * checks that the format of the new valid symbol in F1a matches the type of the FBids (in F1c) which are being merged.
+
+* Additional checks for combination symbol in F1a when F1f is new:
+
+  * Checks that each allele symbol within the combination symbol is associated with a tool (either directly for in vitro construct alleles, or indirectly via inserted element for insertional alleles) that is a 'split system component' or one of its children, and warns if not.
+    * NOTE that this check is only performed if the allele symbol is already in chado (which is the normal case); if the allele is newly generated in the record, a warning saying that the extra checks cannot be carried out.
+
+  * If the tool associated with the allele is either 'split driver - DNA-binding fragment' or 'split driver - transcription activation fragment', checks that the allele is in the expected position within the combination symbol (expects DBD first, then AD).
+    * NOTE that this check is only performed if the allele symbol is already in chado (which is the normal case); if the allele is newly generated in the record, a warning saying that the extra checks cannot be carried out.
+    * NOTE that this check will give false-positives if a combination symbol contains more than two alleles, but this is a very rare case.
+
+  * For combinations containing two allele symbols (i.e. allelesymbol1&cap;allelesymbol2), checks whether the symbol made by reversing the allele symbols (i.e. allelesymbo21&cap;allelesymbol1) already exists in chado.
+
+  If it does:
+
+    * for brand new combinations or merges, warns if so and suggests that the curator may want to use the existing 'reversed' symbol (to try to prevent possible duplication of the same combination in chado with different orders of the same comnbination of allele symbols).
+
+    * for combination renames:
+
+      * If the 'reversed' F1a symbol is the same as that in the rename field, prints a message checking that the intention was to reverse the allele symbol components.
+      * If the 'reversed' F1a symbol is NOT the same as that in the rename field, warns that there is an error and need to either choose a new symbol in F1a, or fix FBid in F1f.
+
 
 ### Related fields:
 
@@ -75,4 +99,4 @@ The following two checks are done at the end of proforma checking within express
 
 ### Updated:
 
-gm170206.
+gm230913.

--- a/doc/specs/expression/F1b.txt
+++ b/doc/specs/expression/F1b.txt
@@ -26,7 +26,7 @@ No (Implemented)
 
 Cross-checks within field
 
-  * the data must either be empty or be a single valid symbol of a gene product (i.e. FBtr or FBpp) which exists in Chado. (in validate_rename)
+  * the data must either be empty or be a single valid symbol of a gene product (i.e. FBtr, FBpp or FBco) which exists in Chado. (in validate_rename)
 
   * sub 'no_hashes_in_proforma'- checks that there are no hashes in the entire proforma if F1b is filled in
 
@@ -40,7 +40,7 @@ Cross-checks with other fields
 
 The following check is done at the end of proforma checking within expression.pl, rather than trying to add it to the 'cross_check_harv_style_symbol_rename_merge_fields' subroutine which is used for several different 'Harvard' style proformae:
 
-* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f (i.e. either genesymbol-XR or allelesymbolRA for a FBtr id, either genesymbol-XP or allelesymbolPA for a FBpp id).
+* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f (e.g. either genesymbol-XR or allelesymbolRA for a FBtr id, either genesymbol-XP or allelesymbolPA for a FBpp id).
 
 ### Related fields:
 
@@ -55,4 +55,4 @@ The following check is done at the end of proforma checking within expression.pl
 
 ### Updated:
 
-gm160328.
+gm230912.

--- a/doc/specs/expression/F1c.txt
+++ b/doc/specs/expression/F1c.txt
@@ -58,7 +58,7 @@ The following check is done at the end of proforma checking within expression.pl
 
 * If gene products are being merged:
 
-  * checks that the FBids in F1c (merge field) are all of one type (i.e. FBtr or FBpp) and prints an error message if not.
+  * checks that the FBids in F1c (merge field) are all of one type (i.e. FBtr, FBpp or FBco) and prints an error message if not.
   * checks that the format of the new valid symbol in F1a matches the type of the FBids (in F1c) which are being merged.
 
 ### Related fields:
@@ -77,4 +77,4 @@ The following check is done at the end of proforma checking within expression.pl
 
 ### Updated:
 
-gm160328.
+gm230912.

--- a/doc/specs/expression/F1f.txt
+++ b/doc/specs/expression/F1f.txt
@@ -33,9 +33,9 @@ Checks within field:
 
 in 'validate_primary_FBid_field':
 
-* each entry must either be the string 'new' or an FBid number of the types expected for the proforma (ie. FBpp or FBtr)
+* each entry must either be the string 'new' or an FBid number of the types expected for the proforma (ie. FBpp, FBtr or FBco)
 
-* if the entry is an FBid (ie. FBpp or FBtr) number, it must be valid in chado.
+* if the entry is an FBid (ie. FBpp, FBtr or FBco) number, it must be valid in chado.
 
 
 
@@ -52,7 +52,13 @@ sub 'cross_check_harv_style_symbol_rename_merge_fields' - see MA1f.txt for detai
 
 The following check is done at the end of proforma checking within expression.pl, rather than trying to add it to the 'cross_check_harv_style_symbol_rename_merge_fields' subroutine which is used for several different 'Harvard' style proformae:
 
-* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f (i.e. either genesymbol-XR or allelesymbolRA for a FBtr id, either genesymbol-XP or allelesymbolPA for a FBpp id).
+* If the gene product is being renamed, checks that the format of the new valid symbol in F1a matches the type of FBid in F1f. Allowed formats are:
+
+  * either genesymbol-XR or allelesymbolRA for a FBtr id
+
+  * either genesymbol-XP or allelesymbolPA for a FBpp id
+
+  * allelesymbol&cap;allelesymbol for a FBco id
 
 
 ### Related fields:
@@ -70,4 +76,4 @@ The following check is done at the end of proforma checking within expression.pl
 
 ### Updated:
 
-gm160328.
+gm230912.

--- a/doc/specs/expression/F2.txt
+++ b/doc/specs/expression/F2.txt
@@ -32,10 +32,13 @@ Checks within field:
 Checks between fields:
 
 
-* F2 must only be filled in if expression is from a transgene, i.e. gene product symbol has format of either allelesymbolRA (FBtr) or allelesymbolPA (FBpp)
+* F2 must only be filled in if expression is from either:
+
+  * a transgene, i.e. gene product symbol has format of either allelesymbolRA (FBtr) or allelesymbolPA (FBpp)
+  * a combination (FBco)
 
 
-* F2 must be filled in for a transgene if F1f is 'new' (i.e. for new objects and merges)
+* F2 must be filled in for a transgene or combination if F1f is 'new' (i.e. for new objects and merges)
 
 
 
@@ -53,4 +56,4 @@ Checks between fields:
 
 ### Updated:
 
-gm170201.
+gm230912.

--- a/doc/specs/expression/F3.txt
+++ b/doc/specs/expression/F3.txt
@@ -26,11 +26,13 @@ No (implemented)
 
 Checks between fields:
 
-- allowed SO term id pair depends on the type of gene product in F1a, so format checking of value in the field is done during between field cross-checks, rather than as a within field check.
+- allowed CV term id pair depends on the type of gene product in F1a, so format checking of value in the field is done during between field cross-checks, rather than as a within field check.
 
-  * if the gene product is an FBtr, the 'SO term id' pair must be a child of 'transcript' (or the term itself)
+  * if the gene product is an FBtr, the 'CV term id' pair must be a child of the SO term 'transcript' (or the term itself)
 
-  * if the gene product is an FBpp, the 'SO term id' pair must be a child of 'polypeptide' (or the term itself) (in practise at the moment this means just 'polypeptide' is allowed).
+  * if the gene product is an FBpp, the 'CV term id' pair must be a child of the SO term 'polypeptide' (or the term itself) (in practise at the moment this means just 'polypeptide' is allowed).
+
+  * if the gene product is an FBco, the 'CV term id' pair must be a child of the FBcv term 'split system combination' (or the term itself) (in practise at the moment this means just 'split system combination' is allowed).
 
 - F3 must be filled in for new gene products and for gene product merges.
 
@@ -49,4 +51,4 @@ Although expression curation manual says that this field is required (inclusion 
 
 ### Updated:
 
-gm200514.
+gm230912.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.46"; #  DC-1043: Fix FBtc valid symbol lookup to cope with symbols with superscripts/subscripts.
+our $Peeves_version = "2.47.6"; #  DC-1047: adding checks to warn if F11 fields filled in for FBco.
 
 =head2 Version
 
@@ -270,7 +270,7 @@ our $standard_symbol_mapping = {
 		species_prefix => '1',
 	},
 	'F' => {
-		id => ['FBpp', 'FBtr'],
+		id => ['FBpp', 'FBtr', 'FBco'],
 		type => 'gene product',
 		style => 'Harvard',
 # the following fields must be specified for the expression.pro, because they do not follow the

--- a/production/chado.pl
+++ b/production/chado.pl
@@ -428,9 +428,48 @@ sub set_up_chado_queries ()
 								  AND fc.feature_cvterm_id = fcvtp.feature_cvterm_id
 								  AND fcvtp.type_id = cvt2.cvterm_id
 								  AND cvt2.name = \'common_tool_uses\';');
+## Queries for additional checks for new FBco symbols
+## tool field information (can be used for FBal or FBtp)
+## need to specify FBal/FBtp id and type of feature_relationship
+
+	$prepared_queries{'tool_relationship'} = $chado->prepare ('SELECT f2.uniquename
+								  FROM feature f1, feature f2,
+								       feature_relationship fr, cvterm cv
+								  WHERE f1.uniquename=?
+								  AND f1.feature_id = fr.subject_id
+								  AND f2.feature_id = fr.object_id
+								  AND cv.cvterm_id=fr.type_id
+								  AND cv.name=?;');
 
 
-# cvterm information
+## query to get inserted elements (can be FBtp or FBte) for alleles that are associated with an insertion
+## need to provide FBal number
+	$prepared_queries{'inserted_element'} = $chado->prepare ('SELECT f3.uniquename
+								  FROM feature f1, feature f2, feature f3,
+								       feature_relationship fr, cvterm cv,
+								       feature_relationship fr2, cvterm cv2
+								  WHERE f1.uniquename =?
+								  AND f1.feature_id = fr.subject_id
+								  AND f2.feature_id = fr.object_id
+								  AND f2.uniquename like \'FBti%\'
+								  AND cv.cvterm_id=fr.type_id
+								  AND cv.name=\'associated_with\'
+								  AND f2.feature_id = fr2.subject_id
+								  AND f3.feature_id = fr2.object_id
+								  AND cv2.cvterm_id=fr2.type_id
+								  AND cv2.name=\'producedby\';');
+
+## get tool uses information
+	$prepared_queries{'tool_uses'} = $chado->prepare ('SELECT cvt.name
+							   FROM feature f, cvterm cvt, feature_cvterm fcvt, feature_cvtermprop fcp, cvterm cvt2, cv
+							   WHERE fcvt.feature_id = f.feature_id
+							   AND fcvt.feature_cvterm_id = fcp.feature_cvterm_id
+							   AND fcp.type_id = cvt2.cvterm_id
+							   AND cvt2.name = \'tool_uses\'
+							   AND f.uniquename =?
+							   AND fcvt.cvterm_id = cvt.cvterm_id
+							   AND cvt2.cv_id = cv.cv_id
+							   AND cv.name = \'feature_cvtermprop type\';');
 
 ## SO
 

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -38,6 +38,7 @@ my %chadotypes = (
 
 	'FBin' => 'interaction', # FBin is a made up FBid type so that can re-use code in valid_symbol, but treat it as a special case (the uniquenames actually start with an FBrf id, so have to be careful not to pollute the FBrf part of the symbol table).
 
+	'FBco' => 'feature', # type for combinations of hemidrivers
 );
 
 
@@ -891,6 +892,8 @@ my $dv_short_qualifiers = {
 ## the following is stored as a temporary measure, until the 'in vitro construct - X' terms can be obsoleted in the ontology. The stored values are used in validate_cvterm_field (tools.pl) to remind curators that most child 'in vitro construct - X' terms are no longer used for the GA8 field, and that the parent term should be used instead. The value of the key below is '0' NOT '1' which prevents the parent term being stored
 ## once terms are removed from ontology, the line below can be removed
 		'in vitro construct' => '0',
+		'split system combination' => '1', # for validation of F3 for FBco
+		'split system component' => '1', # for validation that components of combination symbol are split system components
 	};
 
 	&process_ontology_file ($FBcv_obo, 'FBcv:\d{1,}', '1', $fbcv_ancestors);
@@ -979,6 +982,18 @@ my $dv_short_qualifiers = {
 
 	}
 
+
+# pair of terms for checking order of allele symbol components of a new FBco symbol
+	my @FBco_order_terms = ('split driver - DNA-binding fragment', 'split driver - transcription activation fragment');
+
+# using for instead of foreach, so can set the value (which is returned by valid_symbol) to specify the position in which an allele of this type is expected to appear in the FBco symbol.
+	for (my $i = 0; $i <= $#FBco_order_terms; $i++) {
+
+		set_symbol ($FBco_order_terms[$i], 'FBco_order', $i + 1);
+
+		valid_symbol ($FBco_order_terms[$i], 'FBcv:default') or print "MAJOR PEEVES ERROR in basic ontology processing: the '$FBco_order_terms[$i]' term listed in Peeves as term used to check the order of components of a new FBco symbol is no longer a valid FBcv term, Peeves will need altering to cope (probably by replacing this obsolete term with a new valid one).\n\n";
+
+	}
 
 #  Then various classes of essentially static symbols.  This code looks ugly but the lists have to live
 #  somewhere and this is as good a place as any.

--- a/records2test/DC-1047/al1.edit
+++ b/records2test/DC-1047/al1.edit
@@ -1,0 +1,110 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0075340
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :Record to test additional checking of FBco symbol when F1f = new
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R94B10]&cap;Scer\GAL4[dsx-GAL4-DBD]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :Scer\GAL4[dsx-GAL4-DBD] is an insertion line, and is  a split system component, but in wrong position
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Hsap\RELA[AD.1xCRE]&cap;Avic\GFP[tdGFP.Dsim\Or67a.P.Tag:M(hCD4)]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :Avic\GFP[tdGFP.Dsim\Or67a.P.Tag:M(hCD4)] has multiple encoded tools, neither is split system component
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Avic\GFP[TN-L15.UAS]&cap;Scer\GAL4[M13::GAL4DBDo.nSyb]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :Avic\GFP[TN-L15.UAS] has a single tool, with multiple uses, neither is a split component.
+Scer\GAL4[M13::GAL4DBDo.nSyb] has a single tool with multiple uses, one is a split component, but is in wrong place in symbol.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Hsap\RELA[AD.R47A04]&cap;Scer\GAL4[DBD.8xlexAop]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :symbol in F1a is a reverse of FBco0002135
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0002074
+! F1a. Gene product symbol           :Hsap\RELA[AD.VT050660]&cap;Ecol\lexA[DBD.VT049484]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :Ecol\lexA[DBD.VT049484]&cap;Hsap\RELA[AD.VT050660]
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :reversing component orders - F1b is current symbol
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0001755
+! F1a. Gene product symbol           :Hsap\RELA[AD.R93D10]&cap;Ecol\lexA[DBD.R13F04]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :Ecol\lexA[DBD.ort]&cap;Hsim\VP16[ET77B]
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :rename where what is being put in F1a is the reverse of an existing combination (FBco0002064), but not the same FBid as in F1b
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1047/gm1.edit
+++ b/records2test/DC-1047/gm1.edit
@@ -1,0 +1,68 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0000001
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R22B12]&cap;Hsap\RELA[AD.R14E06]
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??this should pass??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0000002
+! F1a. Gene product symbol           :wrong symbol
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??this should fail as symbol does not match FBid??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0000003
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R13F04]&cap;Hsap\RELA[AD.R93D10]
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??this should fail as the symbol is actually for FBco0000004??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1047/gm2.edit
+++ b/records2test/DC-1047/gm2.edit
@@ -1,0 +1,102 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0000010
+! F1a. Gene product symbol           :Scer\GAL4[newDBD]&cap;Hsap\RELA[AD.R24E06.same]
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :Scer\GAL4[DBD.Tdc2]&cap;Hsap\RELA[AD.R24E06]
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F13. Comment  [free text]       :check whether old symbol @Scer\GAL4[DBD.Tdc2]&cap;Hsap\RELA[AD.R24E06]@ generates an invalid stamp message.
+Second check: new symbol @Scer\GAL4[newDBD]&cap;Hsap\RELA[AD.R24E06.same]@ should NOT generate an invalid stamp message.
+! F14. Internal note  [free text] :??this tests a rename: should get error message saying that symbol in F1a is based on an invalid FBal symbol, for both halves
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBtr0000004
+! F1a. Gene product symbol           :Ecol\lacZ[svp-3_rename]RA
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :Ecol\lacZ[svp-3]RA
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??this tests a rename: should get an error message of form
+F1a: 'Ecol\lacZ[svp-3_rename]RA' gene product symbol is based on the invalid FBal symbol 'Ecol\lacZ[svp-3_rename]'
+as Ecol\lacZ[svp-3_rename] is not a valid allele symbol
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBtr0000005
+! F1a. Gene product symbol           :Ecol\lacZ[hkb.0.4]RA
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :Ecol\lacZ[hkb-s5953]RA
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F13. Comment  [free text]       :this is valid: @Ecol\lacZ[hkb.0.4]RA@, this is not @Ecol\lacZ[hkb-s5953]RA@.
+! F14. Internal note  [free text] :??this tests a rename: this should pass as Ecol\lacZ[hkb.0.4] is a valid symbol
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0000006
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R94B10]&cap;Hsap\RELA[AD.invalid]
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :Scer\GAL4[DBD.R94B10]&cap;Hsap\RELA[AD.R20A02]
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+! F13. Comment  [free text]       :
+!
+! F14. Internal note  [free text] :??this tests a rename: should get error message saying that symbol in F1a is based on an invalid FBal symbol, just for Hsap\RELA[AD.invalid]
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R94B10]&cap;Ecol\lacZ[invalid]&cap;Scer\FLP1[187A]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??this test if copes with multiple &cap;
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1047/gm3.edit
+++ b/records2test/DC-1047/gm3.edit
@@ -1,0 +1,70 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0075340
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Scer\GAL4[DBD.R42H01]&cap;Hsap\RELA[AD.ple]
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :FBco0000040
+FBco0000035
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??testing merge - OK
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :new&cap;intersection_symbol
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :FBco0000028
+FBtr0000004
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??testing merge - error multiple Fbid types in F1c
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :dpp-XR
+! F3.  Gene product type [CV]        :
+! F2.  Sequence attribute [CV]	     :
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :FBco0000020
+FBco0000021
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??should give error - mismatch between type of id in F1c and syntax of new symbol in F1a
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1047/gm4.edit
+++ b/records2test/DC-1047/gm4.edit
@@ -1,0 +1,68 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0046057
+! P2.   Parent multipub abbreviation               *w :Development
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :another&cap;newsymbol
+! F3.  Gene product type [CV]        :split system combination FBcv:0009026
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :FBco0000040
+FBco0000035
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :Scer\GAL4[dpp.PU]&cap;Scer\GAL4[hh.PU]
+! F3.  Gene product type [CV]        :polypeptide SO:0000104
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??wrong F3 value - put value for FBpp in
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :new
+! F1a. Gene product symbol           :more&cap;examples
+! F3.  Gene product type [CV]        :wrong term SO:1238434
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F14. Internal note  [free text] :??wrong F3 value - not valid term
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1047/sm1.edit
+++ b/records2test/DC-1047/sm1.edit
@@ -1,0 +1,42 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0075340
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :Record to test additional checking of FBco symbol when F1f = new
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! GENEPRODUCT ATTRIBUTES/EXPRESSION PROFORMA       Version 10: 02 Jul 2014
+!
+! F1f. Database id (default 'new')   :FBco0002074
+! F1a. Gene product symbol           :Ecol\lexA[DBD.VT049484]&cap;Hsap\RELA[AD.VT050660]
+! F3.  Gene product type [CV]        :split system combination
+! F2.  Sequence attribute [CV]	     :synthetic_sequence SO:0000351
+!
+! F1b. Action - rename this gene product (symbol)      :
+! F1c. Action - merge these products(s) (symbols or FB#s) :
+! F1d. Action - delete gene product record ("y"/blank) :
+! F1e. Action - dissociate F1f from FBrf ("y"/blank)   :
+!
+! F11. Expression pattern ascribed to (gene symbol) :dpp
+!     F11a. Is subset of wild-type gene expression pattern (y/n) :n
+!     F11b. Is pattern aberrant relative to wild-type (y/n) :n
+! F14. Internal note  [free text] :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
…hru 2.47.6

changes for new FB (combination) type.

Summary of changes:

chado.pl - 3 new queries to pull out experimental tool info for alleles (so can add QC checks on the allele components of the symbol in F1a for new combinations/merge/renames)

symtab.pl - addition of FBco feature type, addition of some CV terms (so can add QC checks on the allele components of the symbol in F1a for new combinations/merge/renames)

tools.pl - main change is in type_gene_product - now returns values for combinations (matching .+&cap;.+) so that more detailed checking can be done in expression.pl

expression.pl
- add warning if F11, F11a, F11b filled in for FBco (as not appropriate)
- add code so checks for correct values for FBco in F2 and F3 when filled in
- main change is lines 308-417 of this file - adds the QC checks on the allele components of the symbol in F1a for new combinations/merge/renames - the additional lines from line 67 onwards in the doc/specs/expression/F1a.txt file detail what the QC checks are
