### PR TITLE
Dc 911 dc 913

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -974,3 +974,7 @@ our $Peeves_version = "2.47.4"; #  DC-1047: adding checks for FBco in F2 and F3 
 our $Peeves_version = "2.47.5"; #  DC-1047: adding extra checks for new FBco symbols (check that each allele is a split system component, and that bits are in the correct order).
 # 15.9.2023
 our $Peeves_version = "2.47.6"; #  DC-1047: adding checks to warn if F11 fields filled in for FBco.
+# 9.10.2023
+our $Peeves_version = "2.48.1"; #  DC-911: allow FBsf in allele.pro experimental tools symbol fields.
+our $Peeves_version = "2.48.2"; #  DC-913: allow FBsf in moseg.pro experimental tools symbol fields.
+our $Peeves_version = "2.48.3"; #  Allow FBsf in free text in stamps (relates to DC-911 and DC-913).

--- a/doc/specs/allele/GA30a.txt
+++ b/doc/specs/allele/GA30a.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 Checks between fields:
 
@@ -57,4 +57,4 @@ Some of the between fields cross-checks are not carried out for .edit records, t
 
 ### Updated:
 
-gm180412.
+gm231009.

--- a/doc/specs/allele/GA30b.txt
+++ b/doc/specs/allele/GA30b.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 ### Related fields:
 
@@ -53,4 +53,4 @@ Some of the between fields cross-checks are not carried out for .edit records, t
 
 ### Updated:
 
-gm180412.
+gm231009.

--- a/doc/specs/allele/GA30c.txt
+++ b/doc/specs/allele/GA30c.txt
@@ -28,7 +28,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 Cross-checks between fields:
 
@@ -63,4 +63,4 @@ Some of the between fields cross-checks are not carried out for .edit records, t
 
 ### Updated:
 
-gm211123.
+gm231009.

--- a/doc/specs/allele/GA30e.txt
+++ b/doc/specs/allele/GA30e.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid gene or tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid gene, tool or sequence feature symbol either in chado or generated in the record.
 
 Checks between fields:
 
@@ -56,4 +56,4 @@ Some of the between fields cross-checks are not carried out for .edit records, t
 
 ### Updated:
 
-gm180411.
+gm231009.

--- a/doc/specs/moseg/MS14a.txt
+++ b/doc/specs/moseg/MS14a.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 ### Related fields:
 
@@ -47,4 +47,4 @@ If end up having a moseg.pro field to replace current MS22 (localized function) 
 
 ### Updated:
 
-gm171128.
+gm231009.

--- a/doc/specs/moseg/MS14b.txt
+++ b/doc/specs/moseg/MS14b.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 ### Related fields:
 
@@ -42,5 +42,5 @@ Checks within field:
 
 ### Updated:
 
-gm171128.
+gm231009.
 

--- a/doc/specs/moseg/MS14c.txt
+++ b/doc/specs/moseg/MS14c.txt
@@ -28,7 +28,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid tool or sequence feature symbol either in chado or generated in the record.
 
 
 ### Related fields:
@@ -54,4 +54,4 @@ If end up having a moseg.pro field to replace current MS22 (localized function) 
 
 ### Updated:
 
-gm171128.
+gm231009.

--- a/doc/specs/moseg/MS14e.txt
+++ b/doc/specs/moseg/MS14e.txt
@@ -27,7 +27,7 @@ No (implemented)
 
 Checks within field:
 
-* check_valid_symbol_field checks that the values are a valid gene or tool symbol either in chado or generated in the record.
+* check_valid_symbol_field checks that the values are a valid gene, tool symbol or sequence feature either in chado or generated in the record.
 
 ### Related fields:
 
@@ -48,4 +48,4 @@ If end up having a moseg.pro field to replace current MS22 (localized function) 
 
 ### Updated:
 
-gm171128.
+gm231009.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.47.6"; #  DC-1047: adding checks to warn if F11 fields filled in for FBco.
+our $Peeves_version = "2.48.3"; #  Allow FBsf in free text in stamps (relates to DC-911 and DC-913).
 
 =head2 Version
 

--- a/production/tools.pl
+++ b/production/tools.pl
@@ -444,7 +444,7 @@ sub check_stamps ($$$)
 
 # list of FlyBase types that can be used in @@ - tried to order them so that most likely types are checked first
 # not included by might want to consider adding: FBgg
-		my @allowed_types = ('FBgn', 'FBto', 'FBal', 'FBti', 'FBtp', 'FBab', 'FBba', 'FBte', 'FBmc', 'FBlc', 'FBcl', 'FBtr', 'FBpp', 'FBtc', 'FBco');
+		my @allowed_types = ('FBgn', 'FBto', 'FBal', 'FBti', 'FBtp', 'FBab', 'FBba', 'FBte', 'FBmc', 'FBlc', 'FBcl', 'FBtr', 'FBpp', 'FBtc', 'FBco', 'FBsf');
 		valid_symbol_of_list_of_types ($1, \@allowed_types) or report ($file, "%s: Invalid stamp \@%s\@ in '%s'", $code, $1, $data);
 	}
     }
@@ -538,7 +538,7 @@ sub check_stamps_with_ids {
 
 			# list of FlyBase types that can be used in @@ - tried to order them so that most likely types are checked first
 			# not included by might want to consider adding: FBgg
-			my @allowed_types = ('FBgn', 'FBto', 'FBal', 'FBti', 'FBtp', 'FBab', 'FBba', 'FBte', 'FBmc', 'FBlc', 'FBcl', 'FBtr', 'FBpp', 'FBtc', 'FBco');
+			my @allowed_types = ('FBgn', 'FBto', 'FBal', 'FBti', 'FBtp', 'FBab', 'FBba', 'FBte', 'FBmc', 'FBlc', 'FBcl', 'FBtr', 'FBpp', 'FBtc', 'FBco', 'FBsf');
 			valid_symbol_of_list_of_types ($1, \@allowed_types) or report ($file, "%s: Invalid stamp \@%s\@ in '%s'", $code, $1, $data);
 		}
 	}
@@ -2485,15 +2485,15 @@ sub check_valid_symbol_field {
 		'TO7b' => ['FBto'],
 		'TO7c' => ['FBgn'],
 
-		'GA30a' => ['FBto'],
-		'GA30b' => ['FBto'],
-		'GA30c' => ['FBto'],
-		'GA30e' => ['FBgn', 'FBto'],
+		'GA30a' => ['FBto', 'FBsf'],
+		'GA30b' => ['FBto', 'FBsf'],
+		'GA30c' => ['FBto', 'FBsf'],
+		'GA30e' => ['FBgn', 'FBto', 'FBsf'],
 
-		'MS14a' => ['FBto'],
-		'MS14b' => ['FBto'],
-		'MS14c' => ['FBto'],
-		'MS14e' => ['FBgn', 'FBto'],
+		'MS14a' => ['FBto', 'FBsf'],
+		'MS14b' => ['FBto', 'FBsf'],
+		'MS14c' => ['FBto', 'FBsf'],
+		'MS14e' => ['FBgn', 'FBto', 'FBsf'],
 
 		'MS23' => ['FBal'],
 

--- a/records2test/DC-1047/sm1.edit
+++ b/records2test/DC-1047/sm1.edit
@@ -7,7 +7,7 @@
 ! P42.  Flag Ontologists for curation           ONTO :
 ! P43.  Flag Disease for curation            DISEASE :
 ! P44.  Disease(s) relevant to FBrf      [free text] :
-! P19.  Internal notes                   *H :Record to test additional checking of FBco symbol when F1f = new
+! P19.  Internal notes                   *H :Record to test that get warning if any of the F11 fields are filled in for FBco
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! GENE DATA
 ! Insert gene proforma below.

--- a/records2test/DC-911/gm1.edit
+++ b/records2test/DC-911/gm1.edit
@@ -1,0 +1,77 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0228444
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Scer\GAL4
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Scer\GAL4[VT000002]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA30e. Regulatory region(s) present (symbol)  :VT000002
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm2.edit
+++ b/records2test/DC-911/gm2.edit
@@ -1,0 +1,77 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0208510
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :bsk
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :bsk[KK108156]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :dsRNA-KK108156
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm3.edit
+++ b/records2test/DC-911/gm3.edit
@@ -1,0 +1,78 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0234795
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :CG33096
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :CG33096[TOE.GS00002]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :sgRNA-GS00002.1
+sgRNA-GS00002.2
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm4.edit
+++ b/records2test/DC-911/gm4.edit
@@ -1,0 +1,79 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Ecol\lacZ
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Ecol\lacZ[tld.eve.-42]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :GFP
+VT000002
+! GA30b. Other experimental tools carried (FBto symbol)     :Wari
+FRT
+! GA30c. Encoded experimental tool (FBto symbol)  :
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm5.edit
+++ b/records2test/DC-911/gm5.edit
@@ -1,0 +1,79 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Apc
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Apc[R17C06.test.sgRNA]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :n
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :NEW:P{R17C06-Apc.test}
+! GA10b. Construct symbol(s) used in reference               *L :R17C06-GFP
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :in vitro construct
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :sgRNA
+! GA30e. Regulatory region(s) present (symbol)  :GMR17C06
+hh
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :@GMR17C06@ and @hh@ regulatory sequences drive expression of @sgRNA-GS00007.1@.
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :sgRNA-GS00007.1
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm6.edit
+++ b/records2test/DC-911/gm6.edit
@@ -1,0 +1,77 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Apc
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Apc[R17C06.test.sgRNA]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+!c GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+!c GA30c. Encoded experimental tool (FBto symbol)  :GFP
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/gm7.edit
+++ b/records2test/DC-911/gm7.edit
@@ -1,0 +1,129 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :dpp
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 63: 16 Apr 2020
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :dpp[newALLELE]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :n
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :NEW:P{UAS-dpp.shRNAnew}
+! GA10b. Construct symbol(s) used in reference               *L :UAS-someconstruct
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :in vitro construct
+! GA36.  Allele/construct is associated with disease? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA30e. Regulatory region(s) present (symbol)  :UAS
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :@UAS@ regulatory sequences drive expression of the an shRNA that targets @dpp@.
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :shRNA.dpp.test
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! SEQUENCE FEATURE/MAPPED ENTITIES PROFORMA    Version 7: 25 Nov 2020
+!
+! SF1f. Database ID for feature         :new
+! SF1a. Feature symbol to use in database    :shRNA.dpp.test
+! SF1b. Symbol used in paper/source          :
+! SF2a. Feature macromolecular category [CV] :RNA
+! SF2b. Feature description [CV]        :RNAi_reagent
+!
+! SF1c. Action - rename this feature         :
+! SF1g. Action - merge these features        :
+! SF1h. Action - delete feature record ("y"/blank)   :
+! SF1i. Action - dissociate SF1f from FBrf ("y"/blank) :
+!
+! SF3a. From dataset/collection (symbol) :
+! SF3c. Type of relationship to dataset/collection [member_of_reagent_collection/experimental_result] :
+! SF3b. Species of derivation            :Dmel
+!
+! SF4a. Genomic location of feature (dupl for multiple) :2L:2428372..2428380
+!   SF4b. Genome release number for entry in SF4a   :6
+!   SF4h. Orientation of feature in SF4a relative to the chromosome ("+"/"-")  :-
+! SF4d. Sequence accession (AC no. | gi no. | date) (dupl for multiple) :
+!   SF4e. Location of start in accession entry  :
+!   SF4f. Location of finish in accession entry :
+! SF4g. Sequence of feature (nt or aa) :
+! SF4c. Comments concerning sequence or sequence location :
+!
+! SF5a. Associated gene(s) (dupl for multiple) :
+!    SF5e. Confidence rating for gene call :
+!    SF5f. Comments concerning gene call :
+! SF5b. Associated allele       :
+! SF5g. Associated transcript   :
+! SF5c. Associated FBtp transgenic_transposable_element (symbol) :
+! SF5h. Associated FBmc engineered_plasmid (symbol) :
+! SF5d. Corresponding segment   :
+!
+! SF10a. Evidence/assay [CV] :
+!
+! SF11a. Bound moiety (FB symbol)   :
+! SF11b. Bound moiety (no FB symbol) :
+! SF11c. Comment concerning bound moiety :
+!
+! SF12. Linked to restriction fragment :
+!
+! SF20a. PCR template [CV] :
+! SF20b. Primer 1 sequence :
+! SF20c. Primer 2 sequence :
+! SF20d. Additional information, primers :
+!
+! SF6. Comments [free text]        :
+! SF7. Information on availability :
+! SF8. Internal notes              :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-911/sm1.edit
+++ b/records2test/DC-911/sm1.edit
@@ -1,0 +1,78 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0108352
+! P2.   Parent multipub abbreviation               *w :Chromosoma
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 79:  3 Oct 2018
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Ecol\uidA
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Ecol\uidA[Bhyg\PC4-1.G3:4]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct represents a human disease-implicated variant? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :
+! GA30e. Regulatory region(s) present (symbol)  :Bhyg\PC4-1
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :Tag:HA
+! GA30b. Other experimental tools carried (FBto symbol)     :attP
+! GA30c. Encoded experimental tool (FBto symbol)  :lacZ
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm10.edit
+++ b/records2test/DC-913/gm10.edit
@@ -1,0 +1,51 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0199194
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :new
+! MS1a. Segment symbol to use in database       :P{somenewsymbol}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :P-element
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :
+! MS14b. Other experimental tools carried (FBto symbol)     :
+! MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :GMR42D04
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm11.edit
+++ b/records2test/DC-913/gm11.edit
@@ -1,0 +1,51 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0102797
+! MS1a. Segment symbol to use in database       :P{VT000108-GAL4}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :
+! MS14b. Other experimental tools carried (FBto symbol)     :
+! MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+!c MS14e. Regulatory region(s) present (symbol) :
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm12.edit
+++ b/records2test/DC-913/gm12.edit
@@ -1,0 +1,103 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :new
+! MS1a. Segment symbol to use in database       :P{UAS-something.newFBsf}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :P-element
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :
+! MS14b. Other experimental tools carried (FBto symbol)     :
+! MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :new_reg_region_for_testing
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! SEQUENCE FEATURE/MAPPED ENTITIES PROFORMA    Version 7: 25 Nov 2020
+!
+! SF1f. Database ID for feature         :new
+! SF1a. Feature symbol to use in database    :new_reg_region_for_testing
+! SF1b. Symbol used in paper/source          :
+! SF2a. Feature macromolecular category [CV] :DNA
+! SF2b. Feature description [CV]        :regulatory_region
+!
+! SF1c. Action - rename this feature         :
+! SF1g. Action - merge these features        :
+! SF1h. Action - delete feature record ("y"/blank)   :
+! SF1i. Action - dissociate SF1f from FBrf ("y"/blank) :
+!
+! SF3a. From dataset/collection (symbol) :
+! SF3c. Type of relationship to dataset/collection [member_of_reagent_collection/experimental_result] :
+! SF3b. Species of derivation            :Dmel
+!
+! SF4a. Genomic location of feature (dupl for multiple) :X:235674..235678
+!   SF4b. Genome release number for entry in SF4a   :6
+!   SF4h. Orientation of feature in SF4a relative to the chromosome ("+"/"-")  :
+! SF4d. Sequence accession (AC no. | gi no. | date) (dupl for multiple) :
+!   SF4e. Location of start in accession entry  :
+!   SF4f. Location of finish in accession entry :
+! SF4g. Sequence of feature (nt or aa) :
+! SF4c. Comments concerning sequence or sequence location :
+!
+! SF5a. Associated gene(s) (dupl for multiple) :
+!    SF5e. Confidence rating for gene call :
+!    SF5f. Comments concerning gene call :
+! SF5b. Associated allele       :
+! SF5g. Associated transcript   :
+! SF5c. Associated FBtp transgenic_transposable_element (symbol) :
+! SF5h. Associated FBmc engineered_plasmid (symbol) :
+! SF5d. Corresponding segment   :
+!
+! SF10a. Evidence/assay [CV] :
+!
+! SF11a. Bound moiety (FB symbol)   :
+! SF11b. Bound moiety (no FB symbol) :
+! SF11c. Comment concerning bound moiety :
+!
+! SF12. Linked to restriction fragment :
+!
+! SF20a. PCR template [CV] :
+! SF20b. Primer 1 sequence :
+! SF20c. Primer 2 sequence :
+! SF20d. Additional information, primers :
+!
+! SF6. Comments [free text]        :
+! SF7. Information on availability :
+! SF8. Internal notes              :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm13.edit
+++ b/records2test/DC-913/gm13.edit
@@ -1,0 +1,52 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0104946
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0145348
+! MS1a. Segment symbol to use in database       :P{TKO.GS00007}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :Insulator_I_4308
+! MS14b. Other experimental tools carried (FBto symbol)     :Wari
+! MS14c. Encoded experimental tool (FBto symbol) :sgRNA-GS00007.1
+sgRNA-GS00007.2
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :VT000002
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm14.edit
+++ b/records2test/DC-913/gm14.edit
@@ -1,0 +1,49 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0000385
+! MS1a. Segment symbol to use in database       :P{27.1}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :w[+mC]
+! MS14a. Tagged with experimental tool (FBto symbol)        :Tag:MYC
+! MS14b. Other experimental tools carried (FBto symbol)     :FRT
+! MS14c. Encoded experimental tool (FBto symbol) :GAL4
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :dpp
+UAS
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :Adding features to MS14 symbol fields (MS14a, MS14b, MS14c, MS14e) that were already allowed (i.e. FBto in all, also FBgn in MS14e), to check that PDEV-178 git change has not broken anything. Also adding a marker allele in MS24 as this field is part of a loop that changed as well.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm15.edit
+++ b/records2test/DC-913/gm15.edit
@@ -1,0 +1,48 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0000385
+! MS1a. Segment symbol to use in database       :P{27.1}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+!c MS24. Marker allele(s) carried (symbol) :
+!c MS14a. Tagged with experimental tool (FBto symbol)        :
+!c MS14b. Other experimental tools carried (FBto symbol)     :loxP
+!c MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+!c MS14e. Regulatory region(s) present (symbol) :hh
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :plingc of fields where data added in gm14.edit - some plingc to nothing, others added new value.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-913/gm9.edit
+++ b/records2test/DC-913/gm9.edit
@@ -1,0 +1,74 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0102797
+! MS1a. Segment symbol to use in database       :P{VT000108-GAL4}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :
+! MS14b. Other experimental tools carried (FBto symbol)     :
+! MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :VT000108
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! MOLECULAR SEGMENT AND CONSTRUCT PROFORMA           Version 32: 25 Nov 2020
+! MS1f. Database ID for segment (FBid or "new") :FBtp0147662
+! MS1a. Segment symbol to use in database       :PBac{Cas9.G4HACK}
+! MS1b. Symbol used in paper                    :
+! MS16. Segment category (type of entity) [CV]  :transgenic_transposable_element
+! MS4a. Description [CV]                        :transposon
+! MS21. Transposon class (generic)              :
+! MS14. Uses [CV]                               :
+! MS22. Localized function [CV]      :
+! MS1c. Action - replace this segment symbol :
+! MS1g. Action - merge these segments (FBid) :
+! MS24. Marker allele(s) carried (symbol) :
+! MS14a. Tagged with experimental tool (FBto symbol)        :
+! MS14b. Other experimental tools carried (FBto symbol)     :
+! MS14c. Encoded experimental tool (FBto symbol) :
+! MS14d. Encoded experimental tool [CV]          :
+! MS14e. Regulatory region(s) present (symbol) :snRNA:U6:96Ac
+! MS15. Moseg description [free text] :
+! MS19a. Progenitor construct (symbol) :
+! MS19b. Progenitor(s) (other - free text) :
+! MS10b. General comments :
+! MS11.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
changes for DC-911 and DC-913:

- allow FBsf in allele.pro experimental tools symbol fields (DC-911)
- allow FBsf in moseg.pro experimental tools symbol fields (DC-913)
- Allow FBsf in free text in stamps (relates to DC-911 and DC-913) - will allow us to use the FBsf symbols in free text descriptions of new constructs