### PR TITLE
Strain and cur update

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -982,3 +982,5 @@ our $Peeves_version = "2.48.3"; #  Allow FBsf in free text in stamps (relates to
 our $Peeves_version = "2.49"; #  add G41 gene.pro field checks (DC-1058).
 # 15.11.2023
 our $Peeves_version = "2.50"; #  add strain proforma checking.
+# 17.11.2023
+our $Peeves_version = "2.51"; #  updating curator information.

--- a/doc/VERSION
+++ b/doc/VERSION
@@ -980,3 +980,5 @@ our $Peeves_version = "2.48.2"; #  DC-913: allow FBsf in moseg.pro experimental 
 our $Peeves_version = "2.48.3"; #  Allow FBsf in free text in stamps (relates to DC-911 and DC-913).
 # 7.11.2023
 our $Peeves_version = "2.49"; #  add G41 gene.pro field checks (DC-1058).
+# 15.11.2023
+our $Peeves_version = "2.50"; #  add strain proforma checking.

--- a/doc/current_status/strain.between_field
+++ b/doc/current_status/strain.between_field
@@ -1,0 +1,76 @@
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :FULL
+! SN1a.  Strain symbol to use in FlyBase                :FULL
+! SN1c.  Strain symbol(s) used in reference             :FULL
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :FULL
+! SN1g.  Strain type (free text; use "wild type")   :NA
+!
+! SN2a.  Action - strain name to use in FlyBase     :FULL
+! SN2b.  Strain name(s) used in reference           :NA
+! SN2c.  Action - replace this strain name          :PARTIAL
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :FULL
+! SN1e.  Action - merge these strains (symbol)                       :FULL
+! SN3a.  Action - obsolete SN1b in FlyBase  (y/blank) TAKE CARE      :NOT YET IMPLEMENTED
+! SN3b.  Action - dissociate SN1b from reference (y/blank) TAKE CARE :PARTIAL
+!
+! SN12.  Description/comments  :NA
+!
+! SN4.   Derived from strain  [symbol] :NOT YET IMPLEMENTED
+!
+! SN5a.  Associated homozygous allele(s)                [symbol] :NA
+! SN5b.  Associated heterozygous allele(s)              [symbol] :NA
+! SN5c.  Associated homozygous aberration(s)            [symbol] :NA
+! SN5d.  Associated heterozygous aberration(s)          [symbol] :NA
+! SN5e.  Associated homozygous transgenic insertion(s)  [symbol] :NA
+! SN5f.  Associated heterozygous transgenic insertion(s)[symbol] :NA
+!
+! SN6a.  Unassigned phenotype(s) (class | qualifier(s))   [FBcv term] :NOT YET IMPLEMENTED
+! SN6b.  Unassigned phenotype(s) (anatomy)                [FBcv term] :NOT YET IMPLEMENTED
+! SN6c.  Selected phenotype(s)   (class | qualifier(s))   [FBcv term] :NOT YET IMPLEMENTED
+! SN6d.  Selected phenotype(s)   (anatomy)                [FBcv term] :NOT YET IMPLEMENTED
+! SN6e.  Unassigned phenotype comments :NOT YET IMPLEMENTED
+! SN6f.  Selected phenotype comments   :NOT YET IMPLEMENTED
+! SN6g.  General phenotype comments    :NA
+!
+! SN15a. Assayed for quantative trait phenotype(s)   [GO term] :NA
+! SN15b. Quantitative trait assay comments                     :NA
+!
+! SN16a. Endosymbiont assay [organism present/organism absent] :NA
+! SN16b. Endosymbiont assay comment                            :NA
+!
+! SN7a.  Natural P-element transposon status [present/absent] :NA
+! SN7b.  Natural hobo transposon status      [present/absent] :NA
+! SN7c.  Natural transposon related comments                  :NA
+!
+! SN8a.  Characterized genome sequence (dupl for multiple) [whole genome or specify arm] :
+! SN8b.  Whole genome sequence accession         :
+! SN8c.  Other genome characterization [SoftCV]  :
+! SN8d.  Characterization comments               :
+!
+! SN9a.  Isogenized chromosome(s)          [X/Y/2/3/4] :
+! SN9b.  Year isogenized (in or prior to)     [YYYY] :
+! SN9c.  Isogenization comment                       :
+! SN9d.  Extracted chromosome(s)           [X/Y/2/3/4] :
+! SN9e.  Inbred?                                   [y] :NA
+! SN9f.  Founded as [isofemale line/multi-female line] :NA
+! SN9g.  Breeding comments                             :NA
+!
+! SN10a.  Introgressed chromosome, arm, or "segment" (dupl for multiple) :
+!   SN10b.  Introgressed chromosome etc. species                [symbol] :
+!   SN10c.  Introgressed chromosome etc. comments  :
+!
+! SN11a. Collection site, country                      :
+! SN11b. Collection site, state or region              :
+! SN11c. Collection site, city or local place name     :
+! SN11d. Collection site, latitude (decimal degrees)   :
+! SN11e. Collection site, longitude (decimal degrees)  :
+! SN11f. Collection date     [MM.DD.YYYY/MM.YYYY/YYYY] :
+! SN11g. Collection season [winter/spring/summer/fall] :
+! SN11h. Collection substrate                          :
+! SN11i. Collection comments                           :
+!
+! SN14.  Member of dataset  [symbol] :NA
+!
+! SN13.  Internal notes   :NA

--- a/doc/current_status/strain.within_field
+++ b/doc/current_status/strain.within_field
@@ -1,0 +1,76 @@
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :FULL
+! SN1a.  Strain symbol to use in FlyBase                :FULL
+! SN1c.  Strain symbol(s) used in reference             :FULL
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :FULL
+! SN1g.  Strain type (free text; use "wild type")   :FULL
+!
+! SN2a.  Action - strain name to use in FlyBase     :FULL
+! SN2b.  Strain name(s) used in reference           :FULL
+! SN2c.  Action - replace this strain name          :BASIC ONLY
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :FULL
+! SN1e.  Action - merge these strains (symbol)                       :FULL
+! SN3a.  Action - obsolete SN1b in FlyBase  (y/blank) TAKE CARE      :FULL
+! SN3b.  Action - dissociate SN1b from reference (y/blank) TAKE CARE :FULL
+!
+! SN12.  Description/comments  :FULL
+!
+! SN4.   Derived from strain  [symbol] :FULL
+!
+! SN5a.  Associated homozygous allele(s)                [symbol] :FULL
+! SN5b.  Associated heterozygous allele(s)              [symbol] :FULL
+! SN5c.  Associated homozygous aberration(s)            [symbol] :FULL
+! SN5d.  Associated heterozygous aberration(s)          [symbol] :FULL
+! SN5e.  Associated homozygous transgenic insertion(s)  [symbol] :FULL
+! SN5f.  Associated heterozygous transgenic insertion(s)[symbol] :FULL
+!
+! SN6a.  Unassigned phenotype(s) (class | qualifier(s))   [FBcv term] :BASIC ONLY
+! SN6b.  Unassigned phenotype(s) (anatomy)                [FBcv term] :BASIC ONLY
+! SN6c.  Selected phenotype(s)   (class | qualifier(s))   [FBcv term] :BASIC ONLY
+! SN6d.  Selected phenotype(s)   (anatomy)                [FBcv term] :BASIC ONLY
+! SN6e.  Unassigned phenotype comments :
+! SN6f.  Selected phenotype comments   :
+! SN6g.  General phenotype comments    :FULL
+!
+! SN15a. Assayed for quantative trait phenotype(s)   [GO term] :
+! SN15b. Quantitative trait assay comments                     :FULL
+!
+! SN16a. Endosymbiont assay [organism present/organism absent] :
+! SN16b. Endosymbiont assay comment                            :
+!
+! SN7a.  Natural P-element transposon status [present/absent] :
+! SN7b.  Natural hobo transposon status      [present/absent] :
+! SN7c.  Natural transposon related comments                  :
+!
+! SN8a.  Characterized genome sequence (dupl for multiple) [whole genome or specify arm] :
+! SN8b.  Whole genome sequence accession         :
+! SN8c.  Other genome characterization [SoftCV]  :
+! SN8d.  Characterization comments               :
+!
+! SN9a.  Isogenized chromosome(s)          [X/Y/2/3/4] :FULL
+! SN9b.  Year isogenized (in or prior to)     [YYYY] :
+! SN9c.  Isogenization comment                       :
+! SN9d.  Extracted chromosome(s)           [X/Y/2/3/4] :FULL
+! SN9e.  Inbred?                                   [y] :FULL
+! SN9f.  Founded as [isofemale line/multi-female line] :FULL
+! SN9g.  Breeding comments                             :FULL
+!
+! SN10a.  Introgressed chromosome, arm, or "segment" (dupl for multiple) :
+!   SN10b.  Introgressed chromosome etc. species                [symbol] :
+!   SN10c.  Introgressed chromosome etc. comments  :
+!
+! SN11a. Collection site, country                      :
+! SN11b. Collection site, state or region              :
+! SN11c. Collection site, city or local place name     :
+! SN11d. Collection site, latitude (decimal degrees)   :
+! SN11e. Collection site, longitude (decimal degrees)  :
+! SN11f. Collection date     [MM.DD.YYYY/MM.YYYY/YYYY] :
+! SN11g. Collection season [winter/spring/summer/fall] :
+! SN11h. Collection substrate                          :
+! SN11i. Collection comments                           :
+!
+! SN14.  Member of dataset  [symbol] :FULL
+!
+! SN13.  Internal notes   :FULL

--- a/doc/new_proforma_template
+++ b/doc/new_proforma_template
@@ -106,9 +106,7 @@ FIELD:
 #	elsif ($field =~ /^(.*?)\s+(??insert field code here??)\..*? :(.*)/s)
 #	{
 #		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
-#	    check_non_utf8 ($file, $2, $3);
-#	    check_non_ascii ($file, $2, $3);
-#	    double_query ($file, $2, $3) or validate_stub ($file, $1, $2, $3);
+#		validate_stub ($file, $1, $2, $3);
 #	}
 
 	elsif ($field =~ /^(.*?)\s+<add code prefix for proforma type e.g. MA here>(.+?)\..*?:(.*)$/s)

--- a/doc/specs/strain/SN12.txt
+++ b/doc/specs/strain/SN12.txt
@@ -1,0 +1,46 @@
+
+## ! SN12.  Description/comments  :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+### Inclusion essential:
+
+No (implemented)
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field: check_stamped_free_text
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN13.txt
+++ b/doc/specs/strain/SN13.txt
@@ -1,0 +1,48 @@
+
+## ! SN13.  Internal notes   :
+
+### Multiple values allowed:
+
+Yes (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field: no_stamps
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN14.txt
+++ b/doc/specs/strain/SN14.txt
@@ -1,0 +1,56 @@
+
+## ! SN14.  Member of dataset  [symbol] :
+
+### Multiple values allowed:
+
+No (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* in sub validate_cvterm_field:
+
+  * check_for_duplicated_lines:
+    * warns if there is a blank line within the data
+    * warns if there are any duplicated values
+
+   * checks value is a valid  dataset/collection (i.e. FBlc) symbol in chado/generated in the record
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN15b.txt
+++ b/doc/specs/strain/SN15b.txt
@@ -1,0 +1,48 @@
+
+## ! SN15b. Quantitative trait assay comments                     :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field: check_stamped_free_text
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1a.txt
+++ b/doc/specs/strain/SN1a.txt
@@ -1,0 +1,55 @@
+
+## ! SN1a.  Strain symbol to use in FlyBase                :
+
+### Multiple values allowed:
+
+No (Implemented: 'single_line' subroutine in loop where the field is identified)
+
+
+### !c Applicable:
+
+No (Implemented: in validate_primary_proforma_field)
+
+
+### Inclusion essential:
+
+Yes (Implemented)
+
+
+### Mandatorially has value:
+
+Yes (Implemented: 'contains_data' subroutine in loop where the field is identified)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within validate_primary_proforma_field:
+
+  * sub validate_primary_proforma_field (see doc/specs/allele/GA1a.txt for details). Note that species abbreviation checks are not carried out in validate_primary_proforma_field for the strain proforma because there is a separate field (SN1f) to specify the species explicitly.
+
+Checks between fields:
+
+* I think that the check for validity of the symbol in this field (either valid Fbsn symbol in chado/generated in record) happens as part of the cross_check_harv_style_symbol_rename_merge_fields subroutine below.
+
+   * subroutine 'cross_check_harv_style_symbol_rename_merge_fields' - see MA1f.txt for details of what this subroutine does.
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1b.txt
+++ b/doc/specs/strain/SN1b.txt
@@ -1,0 +1,66 @@
+
+## ! SN1b.  FlyBase strain ID (FBsn, required if not new)  :new
+
+### Multiple values allowed:
+
+No (implemented)
+
+### !c Applicable:
+
+No
+Implemented (in validate_primary_FBid_field)
+
+
+### Inclusion essential:
+
+Yes (implemented)
+
+
+### Mandatorially has value:
+
+Yes (Implemented)
+Implemented (in validate_primary_FBid_field - checks both for whether the entire field is empty, and also whether individual values in a hashed list are empty)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+in 'validate_primary_FBid_field':
+
+* each entry must either be the string 'new' or an FBid number of the type expected for the proforma (ie. FBto)
+
+* if the entry is an FBto number, it must be valid in chado.
+
+Cross-checks with other fields:
+
+in 'validate_primary_FBid_field':
+
+* The number of entries in the list in TO1f must match the number of entries in the TO1a field
+
+
+Cross-checks done after parsing the entire proforma:
+
+* sub 'cross_check_harv_style_symbol_rename_merge_fields' - see MA1f.txt for details.
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1c.txt
+++ b/doc/specs/strain/SN1c.txt
@@ -1,0 +1,62 @@
+
+## ! SN1c.  Strain symbol(s) used in reference             :
+
+### Multiple values allowed:
+
+
+Yes (implemented)
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* sub 'validate_synonym_field'
+
+  * uses 'check_for_duplicated'_lines to check that there are no duplicated synonyms and no empty lines
+
+  * warns if the synonym is composed entirely of punctuation character(s).
+
+  * warns if the field is filled in for a 'user' or 'auto' curation record.
+
+
+Checks between fields:
+
+
+* sub 'check_unattributed_synonym_correction' checks that the valid symbol is in the symbol synonym field when !c-ing that field or the 'unattributed' pub (this is required, else the object ends up with no valid symbol in chado!)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1d.txt
+++ b/doc/specs/strain/SN1d.txt
@@ -1,0 +1,66 @@
+
+## ! SN1d.  Action - rename this strain symbol (existing symbol)        :
+
+### Multiple values allowed:
+
+No
+Implemented (in validate_rename)
+
+
+### !c Applicable:
+
+No
+Implemented (in validate_rename)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Cross-checks within field
+
+  * the data must either be empty or be a single valid symbol of an experimental tool which exists
+in Chado. (in validate_rename)
+
+  * sub 'no_hashes_in_proforma'- checks that there are no hashes in the entire proforma if SN1d is filled in
+
+Cross-checks with other fields:
+
+  * symbol in SN1d cannot be the same as in SN1a (in validate_rename and cross_check_harv_style_symbol_rename_merge_fields)
+
+Cross-checks with other fields
+
+   * subroutine 'cross_check_harv_style_symbol_rename_merge_fields' - see MA1f.txt for details of what this subroutine does.
+
+    * sub 'rename_merge_check' -  SN1d and SN1e must not both contain data
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1e.txt
+++ b/doc/specs/strain/SN1e.txt
@@ -1,0 +1,67 @@
+
+## ! SN1e.  Action - merge these strains (symbol)                       :
+
+### Multiple values allowed:
+
+Yes (separated by returns)
+Implemented (in validate_merge_using_ids)
+
+
+### !c Applicable:
+
+No
+Implemented (in validate_merge_using_ids)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No
+Implemented (in validate_merge_using_ids)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+  * sub 'no_hashes_in_proforma'- checks that there are no hashes in the entire proforma if SN1e is filled in
+
+  * checks in validate_merge_using_ids - see MA1g.txt for details
+
+Cross-checks with other fields:
+
+    * sub 'plingc_merge_check' - no !c in entire proforma if SN1e is filled in
+
+    * sub 'rename_merge_check' -  SN1d and SN1e must not both contain data
+
+Cross-checks with other fields
+
+   * subroutine 'cross_check_harv_style_symbol_rename_merge_fields' - see MA1f.txt for details of what this subroutine does.
+
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1f.txt
+++ b/doc/specs/strain/SN1f.txt
@@ -1,0 +1,59 @@
+
+## ! SN1f.  Species of strain (predominant if hybrid) [symbol] :
+
+### Multiple values allowed:
+
+No (Implemented)
+
+
+### !c Applicable:
+
+No (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No - see 'Cross-checks done after parsing the entire proforma' below.
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+
+Checks within field (Implemented in validate_species_abbreviation_field):
+
+* The value must be a valid drosophilid species abbreviation.
+
+
+Cross-checks done after parsing the entire proforma:
+
+* check_filled_in_for_new_feature :
+
+  * Must be filled in for a new strain
+
+  * Must NOT be filled in for an existing strain (including strains being renamed or merged).
+
+### Related fields:
+
+
+
+### Comments:
+
+(Have implemented checks the same as for MA20).
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN1g.txt
+++ b/doc/specs/strain/SN1g.txt
@@ -1,0 +1,49 @@
+
+## ! SN1g.  Strain type (free text; use "wild type")   :
+
+### Multiple values allowed:
+
+No (implemented)
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* if SN1g is filled in, 'check_single_allowed_value' subroutine checks that the only allowed value is 'wild type'
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN2a.txt
+++ b/doc/specs/strain/SN2a.txt
@@ -1,9 +1,10 @@
 
-## ! TO2a.  Action - experimental tool name to use in FlyBase       :
+## ! SN2a.  Action - strain name to use in FlyBase     :
 
 ### Multiple values allowed:
 
 No (implemented)
+
 
 ### !c Applicable:
 
@@ -37,11 +38,11 @@ Checks within field
 
 Cross-checks between fields:
 
-* If TO1g (merge field) is filled in, TO2c must not be filled in (compare_field_pairs, pair_test = 'single')
+* If SN1e (merge field) is filled in, SN2c must not be filled in (compare_field_pairs, pair_test = 'single')
 
-* If TO2c is filled in, TO2a must be filled in (compare_field_pairs, pair_test = 'dependent')
+* If SN2c is filled in, SN2a must be filled in (compare_field_pairs, pair_test = 'dependent')
 
-* If TO2c and TO2a are both filled in, they must not be the same value  (compare_field_pairs, identity_test = 'not same')
+* If SN2c and SN2a are both filled in, they must not be the same value  (compare_field_pairs, identity_test = 'not same')
 
 
 ### Related fields:
@@ -58,4 +59,4 @@ Cross-checks between fields:
 
 ### Updated:
 
-gm171114.
+gm231115.

--- a/doc/specs/strain/SN2b.txt
+++ b/doc/specs/strain/SN2b.txt
@@ -1,0 +1,57 @@
+
+## ! SN2b.  Strain name(s) used in reference           :
+
+### Multiple values allowed:
+
+Yes (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+
+Checks within field:
+
+* sub 'validate_synonym_field':
+
+  * uses 'check_for_duplicated'_lines to check that there are no duplicated synonyms and no empty lines
+
+  * warns if the synonym is composed entirely of punctuation character(s).
+
+  * warns if the field is filled in for a 'user' or 'auto' curation record.
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN2c.txt
+++ b/doc/specs/strain/SN2c.txt
@@ -1,9 +1,10 @@
 
-## ! TO2c.  Action - rename this experimental tool name             :
+## ! SN2c.  Action - replace this strain name          :
 
 ### Multiple values allowed:
 
 No (Implemented)
+
 
 ### !c Applicable:
 
@@ -14,9 +15,11 @@ No (Implemented)
 
 No (Implemented)
 
+
 ### Mandatorially has value:
 
 No (Implemented)
+
 
 ### Dupl. for multiple field:
 
@@ -31,11 +34,11 @@ Cross-checks within field:
 
 Cross-checks between fields:
 
-* If TO2c is filled in, TO2a must be filled in (compare_field_pairs, pair_test = 'dependent')
+* If SN1e (merge field) is filled in, SN2c must not be filled in (compare_field_pairs, pair_test = 'single')
 
-* If TO2c and TO2a are both filled in, they must not be the same value  (compare_field_pairs, identity_test = 'not same')
+* If SN2c is filled in, SN2a must be filled in (compare_field_pairs, pair_test = 'dependent')
 
-* If TO1g (merge field) is filled in, TO2c must not be filled in (compare_field_pairs, pair_test = 'single')
+* If SN2c and SN2a are both filled in, they must not be the same value  (compare_field_pairs, identity_test = 'not same')
 
 
 ### Related fields:
@@ -46,9 +49,7 @@ Cross-checks between fields:
 
 
 
-
 ### Status:
-
 
 Not yet implemented:
 
@@ -58,4 +59,4 @@ Not yet implemented:
 
 ### Updated:
 
-gm171114.
+gm231115.

--- a/doc/specs/strain/SN3a.txt
+++ b/doc/specs/strain/SN3a.txt
@@ -1,18 +1,20 @@
 
-## ! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+## ! SN3a.  Action - obsolete SN1b in FlyBase  (y/blank) TAKE CARE      :
 
 ### Multiple values allowed:
 
-No (Implemented)
+No (Implemented in validate_obsolete)
+
 
 ### !c Applicable:
 
-No (Implemented)
+No (Implemented in validate_obsolete)
 
 
 ### Inclusion essential:
 
 No (Implemented)
+
 
 ### Mandatorially has value:
 
@@ -36,7 +38,6 @@ Checks within field (validate_obsolete subroutine)
 * if the field is filled in with 'y' a warning is still given, since this is a potentially dangerous field.
 
 
-
 ### Related fields:
 
 
@@ -44,8 +45,8 @@ Checks within field (validate_obsolete subroutine)
 ### Comments:
 
 
-### Status:
 
+### Status:
 
 Not yet implemented:
 
@@ -54,6 +55,7 @@ Not yet implemented:
 * the value in the primary symbol field must already be in chado
 
 
+
 ### Updated:
 
-gm171114.
+gm231115.

--- a/doc/specs/strain/SN3b.txt
+++ b/doc/specs/strain/SN3b.txt
@@ -1,0 +1,59 @@
+
+## ! SN3b.  Action - dissociate SN1b from reference (y/blank) TAKE CARE :
+
+### Multiple values allowed:
+
+No (Implemented in validate_dissociate)
+
+
+### !c Applicable:
+
+No (Implemented in validate_dissociate)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within validate_dissociate:
+
+* P22 must be the FBrf of a publication existing in Chado
+
+* Must be blank or the single value y (No hashing is allowed, for robust checking)
+
+* If filled in (with 'y') prints a warning so that the curator can check they really meant to fill in the field.
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+Not yet implemented:
+
+* the value in SN1a must be the symbol of a strain already present in Chado, and the rename and merge fields must not be filled in
+
+* all other proforma fields must be blank
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN4.txt
+++ b/doc/specs/strain/SN4.txt
@@ -1,0 +1,55 @@
+
+## ! SN4.   Derived from strain  [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid strain symbol (either in chado or generated in record)
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+Not yet implemented:
+
+Checks between fields:
+
+None of the values in SN4 should be the same as that in SN1a.
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5a.txt
+++ b/doc/specs/strain/SN5a.txt
@@ -1,0 +1,50 @@
+
+## ! SN5a.  Associated homozygous allele(s)                [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid allele symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5b.txt
+++ b/doc/specs/strain/SN5b.txt
@@ -1,0 +1,50 @@
+
+## ! SN5b.  Associated heterozygous allele(s)              [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid allele symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5c.txt
+++ b/doc/specs/strain/SN5c.txt
@@ -1,0 +1,50 @@
+
+## ! SN5c.  Associated homozygous aberration(s)            [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid aberration symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5d.txt
+++ b/doc/specs/strain/SN5d.txt
@@ -1,0 +1,50 @@
+
+## ! SN5d.  Associated heterozygous aberration(s)          [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid aberration symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5e.txt
+++ b/doc/specs/strain/SN5e.txt
@@ -1,0 +1,50 @@
+
+## ! SN5e.  Associated homozygous transgenic insertion(s)  [symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid insertion symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN5f.txt
+++ b/doc/specs/strain/SN5f.txt
@@ -1,0 +1,50 @@
+
+## ! SN5f.  Associated heterozygous transgenic insertion(s)[symbol] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* check_valid_symbol_field sub checks that any value is a valid insertion symbol (either in chado or generated in record)
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN6a.txt
+++ b/doc/specs/strain/SN6a.txt
@@ -1,0 +1,46 @@
+
+## ! SN6a.  Unassigned phenotype(s) (class | qualifier(s))   [FBcv term] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+### !c Applicable:
+
+No (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+
+No (implemented)
+
+### Checks:
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+No checks on content of the field carried out yet - complex phenotypic statement with | 
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN6b.txt
+++ b/doc/specs/strain/SN6b.txt
@@ -1,0 +1,46 @@
+
+## ! SN6b.  Unassigned phenotype(s) (anatomy)                [FBcv term] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+### !c Applicable:
+
+No (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+
+No (implemented)
+
+### Checks:
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+No checks on content of the field carried out yet - complex phenotypic statement with | 
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN6c.txt
+++ b/doc/specs/strain/SN6c.txt
@@ -1,0 +1,46 @@
+
+## ! SN6c.  Selected phenotype(s)   (class | qualifier(s))   [FBcv term] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+### !c Applicable:
+
+No (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+
+No (implemented)
+
+### Checks:
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+No checks on content of the field carried out yet - complex phenotypic statement with | 
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN6d.txt
+++ b/doc/specs/strain/SN6d.txt
@@ -1,0 +1,46 @@
+
+## ! SN6d.  Selected phenotype(s)   (anatomy)                [FBcv term] :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+### !c Applicable:
+
+No (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+
+No (implemented)
+
+### Checks:
+
+
+
+### Related fields:
+
+
+
+### Comments:
+
+No checks on content of the field carried out yet - complex phenotypic statement with | 
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN6g.txt
+++ b/doc/specs/strain/SN6g.txt
@@ -1,0 +1,47 @@
+
+## ! SN6g.  General phenotype comments    :
+
+### Multiple values allowed:
+
+Yes (implemented)
+
+### !c Applicable:
+
+Yes (implemented)
+
+
+### Inclusion essential:
+
+No (implemented)
+
+
+### Mandatorially has value:
+
+No (implemented)
+
+
+### Dupl. for multiple field:
+
+No (implemented)
+
+
+### Checks:
+
+Checks within field: check_stamped_free_text
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN9a.txt
+++ b/doc/specs/strain/SN9a.txt
@@ -1,0 +1,56 @@
+
+## ! SN9a.  Isogenized chromosome(s)          [X/Y/2/3/4] :
+
+### Multiple values allowed:
+
+Yes (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+uses 'validate_cvterm_field' which:
+
+ * check_for_duplicated_lines:
+    * warns if there is a blank line within the data
+    * warns if there are any duplicated values
+
+* checks each value is a valid chromosome (e.g. '2') - the allowed values are stored in symtab.pl with type 'chromosome'.
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN9d.txt
+++ b/doc/specs/strain/SN9d.txt
@@ -1,0 +1,56 @@
+
+## ! SN9d.  Extracted chromosome(s)           [X/Y/2/3/4] :
+
+### Multiple values allowed:
+
+Yes (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+uses 'validate_cvterm_field' which:
+
+ * check_for_duplicated_lines:
+    * warns if there is a blank line within the data
+    * warns if there are any duplicated values
+
+* checks each value is a valid chromosome (e.g. '2') - the allowed values are stored in symtab.pl with type 'chromosome'.
+
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN9e.txt
+++ b/doc/specs/strain/SN9e.txt
@@ -1,0 +1,49 @@
+
+## ! SN9e.  Inbred?                                   [y] :
+
+### Multiple values allowed:
+
+No (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* sub check_single_allowed_value checks that the only allowed value is 'y'
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN9f.txt
+++ b/doc/specs/strain/SN9f.txt
@@ -1,0 +1,49 @@
+
+## ! SN9f.  Founded as [isofemale line/multi-female line] :
+
+### Multiple values allowed:
+
+No (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+* sub validate_cvterm_field checks that the single value is either 'isofemale line' or 'multi-female line'
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/doc/specs/strain/SN9g.txt
+++ b/doc/specs/strain/SN9g.txt
@@ -1,0 +1,49 @@
+
+## ! SN9g.  Breeding comments                             :
+
+### Multiple values allowed:
+
+Yes (Implemented)
+
+
+### !c Applicable:
+
+Yes (Implemented)
+
+
+### Inclusion essential:
+
+No (Implemented)
+
+
+### Mandatorially has value:
+
+No (Implemented)
+
+
+### Dupl. for multiple field:
+
+No (Implemented)
+
+
+### Checks:
+
+Checks within field:
+
+check_stamped_free_text
+
+### Related fields:
+
+
+
+### Comments:
+
+
+
+### Status:
+
+
+
+### Updated:
+
+gm231115.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.50"; #  add strain proforma checking.
+our $Peeves_version = "2.51"; #  updating curator information.
 
 =head2 Version
 

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.49"; #  add G41 gene.pro field checks (DC-1058).
+our $Peeves_version = "2.50"; #  add strain proforma checking.
 
 =head2 Version
 
@@ -167,7 +167,7 @@ sub classify_curator ($$)			### Warning --- this sub is seriously location depen
 # follow other types.  The %fsm hash is keyed by proforma type (lifted directly from the text of the proforma)
 # and its values are regexps which match allowable types for the immediately following proforma.
 
-my $tmn = 'TRANSPOSON INSERTION|MOLECULAR SEGMENT AND CONSTRUCT|NATURAL TRANSPOSON|GENEPRODUCT ATTRIBUTES/EXPRESSION|GENEGROUP|DATASET/COLLECTION|HUMAN HEALTH MODEL|INTERACTION|SEQUENCE FEATURE/MAPPED ENTITIES|CULTURED CELL LINE|EXPERIMENTAL TOOL';	# For brevity below. DOS:Added expression proforma name to end of this list. Although unlikely to ever actually be used after these, this should allow Peeves to accept Expression Proformae.'
+my $tmn = 'TRANSPOSON INSERTION|MOLECULAR SEGMENT AND CONSTRUCT|NATURAL TRANSPOSON|GENEPRODUCT ATTRIBUTES/EXPRESSION|GENEGROUP|DATASET/COLLECTION|HUMAN HEALTH MODEL|INTERACTION|SEQUENCE FEATURE/MAPPED ENTITIES|CULTURED CELL LINE|EXPERIMENTAL TOOL|STRAIN';	# For brevity below. DOS:Added expression proforma name to end of this list. Although unlikely to ever actually be used after these, this should allow Peeves to accept Expression Proformae.'
 
 our %fsm = ('MULTIPUBLICATION'                => 'MULTIPUBLICATION',
 	    'PUBLICATION'                     => "SPECIES|DATABASE|GENE|ABERRATION|$tmn",
@@ -188,6 +188,7 @@ our %fsm = ('MULTIPUBLICATION'                => 'MULTIPUBLICATION',
 		'SEQUENCE FEATURE/MAPPED ENTITIES' => $tmn,
 		'CULTURED CELL LINE' => "$tmn|PUBLICATION",
 		'EXPERIMENTAL TOOL' => $tmn,
+		'STRAIN' => $tmn,
 	    );
 our $want_next;
 
@@ -214,6 +215,7 @@ require "$Peeves_config{'Peeves_path'}/database.pl";
 require "$Peeves_config{'Peeves_path'}/seqfeat.pl";
 require "$Peeves_config{'Peeves_path'}/cellline.pl";
 require "$Peeves_config{'Peeves_path'}/experimental_tool.pl";
+require "$Peeves_config{'Peeves_path'}/strain.pl";
 
 
 if ($Peeves_config{'Where_running'} eq 'Cambridge') {
@@ -347,6 +349,15 @@ our $standard_symbol_mapping = {
 		id => ['FBto'],
 		type => 'experimental tool',
 		style => 'Harvard',
+
+	},
+	'SN' => {
+		id => ['FBsn'],
+		type => 'strain',
+		style => 'Harvard',
+		rename_field => '1d',
+		merge_field => '1e',
+		primary_id_field => '1b',
 
 	},	
 };
@@ -879,6 +890,44 @@ our %field_specific_checks = (
 	'TO9' => \&no_stamps,
 	'TO10' => \&validate_species_abbreviation_field,
 
+# strain proforma
+	'SN1c' => \&validate_synonym_field,
+	'SN1f' => \&validate_species_abbreviation_field,
+	'SN1g' => \&check_single_allowed_value,
+	'SN2a' => \&validate_new_full_name,
+	'SN2b' => \&validate_synonym_field,
+	'SN2c' => \&validate_existing_full_name,
+
+	'SN12' => \&check_stamped_free_text,
+	'SN4' => \&check_valid_symbol_field,
+	'SN5a' => \&check_valid_symbol_field,
+	'SN5b' => \&check_valid_symbol_field,
+	'SN5c' => \&check_valid_symbol_field,
+	'SN5d' => \&check_valid_symbol_field,
+	'SN5e' => \&check_valid_symbol_field,
+	'SN5f' => \&check_valid_symbol_field,
+
+	'SN6a' => '', # is like allele GA56 field, so complex so just basic checks at the moment
+	'SN6b' => '', # is like allele GA56 field, so complex so just basic checks at the moment
+	'SN6c' => '', # is like allele GA56 field, so complex so just basic checks at the moment
+	'SN6d' => '', # is like allele GA56 field, so complex so just basic checks at the moment
+
+	'SN6e' => \&check_stamped_free_text,
+	'SN6f' => \&check_stamped_free_text,
+	'SN6g' => \&check_stamped_free_text,
+
+	'SN15b' => \&check_stamped_free_text,
+
+	'SN9a' => \&validate_cvterm_field,
+	'SN9d' => \&validate_cvterm_field,
+	'SN9e' => \&check_single_allowed_value,
+	'SN9f' => \&validate_cvterm_field,
+	'SN9g' => \&check_stamped_free_text,
+
+	'SN14' => \&check_valid_symbol_field,
+	'SN13' => \&no_stamps,
+
+
 );
 
 ## add comment detailing Peeves version being used
@@ -906,7 +955,8 @@ my %despatch_table = ('MULTIPUBLICATION'                => \&do_multipub_proform
 		      'DATABASE'              => \&do_database_proforma,
 		      'SEQUENCE FEATURE/MAPPED ENTITIES'              => \&do_seqfeat_proforma,
 		      'CULTURED CELL LINE'              => \&do_cellline_proforma,
-				'EXPERIMENTAL TOOL' => \&do_experimental_tool_proforma,
+		      'EXPERIMENTAL TOOL' => \&do_experimental_tool_proforma,
+		      'STRAIN' => \&do_strain_proforma,
 		     );
 # hash for proforma that are not checked because the proforma is new and checking is being implemented in new Harvard python parser.
 my %not_checked = (
@@ -938,6 +988,7 @@ my %good_symbol = (
 			'F1a' => 'MULTI:gene product',
 			'TC1a' => 'FBtc',
 			'TO1a' => 'FBto',
+			'SN1a' => 'FBsn',
 		  );
 
 # Proforma fields which may invalidate one or more symbols.
@@ -978,6 +1029,8 @@ my %bad_symbol = (
 			'TC1g' => 'FBtc',
 			'TO1c' => 'FBto',
 			'TO1g' => 'FBto',
+			'SN1d' => 'FBsn',
+			'SN1e' => 'FBsn',
 
 			
 		 );
@@ -1273,11 +1326,11 @@ init_symbol_table ($Peeves_version, $pcfg, $ccfg);
 # have to switch it off.
 
 	    my @proforma_lines = split (/\n/, $proforma);
-	    foreach (grep /^!c? (G|A|MP|P|GA|MA|AB|MS|TE|DB|LC|GG|HH|IN|SP|DB|SF|TC|TO)\d+[a-z]?\.[^:]+$/, @proforma_lines)
+	    foreach (grep /^!c? (G|A|MP|P|GA|MA|AB|MS|TE|DB|LC|GG|HH|IN|SP|DB|SF|TC|TO|SN)\d+[a-z]?\.[^:]+$/, @proforma_lines)
 	    {
 		report ($file, "Possibly missing colon in '%s'", $_);
 	    }
-	    foreach (grep /^c? (G|A|MP|P|GA|MA|AB|MS|TE|DB|LC|GG|HH|IN|SP|DB|SF|TC|TO)\d+[a-z]?\./, @proforma_lines)
+	    foreach (grep /^c? (G|A|MP|P|GA|MA|AB|MS|TE|DB|LC|GG|HH|IN|SP|DB|SF|TC|TO|SN)\d+[a-z]?\./, @proforma_lines)
 	    {
 		report ($file, "Possibly missing ! in '%s'", $_);
 	    }

--- a/production/strain.pl
+++ b/production/strain.pl
@@ -1,0 +1,342 @@
+# Code to parse STRAIN PROFORMA proformae
+
+use strict;
+# A set of global variables for communicating between different proformae.
+
+our (%fsm, $want_next); # Global variables for finite state machine (defines what proforma expected next)
+our ($chado, %prepared_queries); # Global variables for communication with Chado.
+our %x1a_symbols;						# Hash for detecting duplicate proformae in a record
+our $g_FBrf;							# Publication ID from P22 (if valid FBrf number)
+our $unattributed;              # Set to 1 if P22 = 'unattributed', otherwise '0'
+
+our $change_count = 0; # count of number of !c lines in the proforma, peeves global as needs to be seen by changes in tools.pl,
+
+
+my ($file, $proforma);
+my %proforma_fields;		# Keep track of the latest entry seen for each code
+my %dup_proforma_fields; # keep track of full picture for fields that can be duplicated within a proforma
+my @inclusion_essential = qw (SN1b SN1a);			# Fields which must be present in the proforma
+my %can_dup = ('SN8a' => 1, 'SN8b' => 1, 'SN8c' => 1, 'SN8d' => 1,
+		'SN10a' => 1, 'SN10b' => 1, 'SN10c' => 1,
+	       );		# Fields which may be duplicated in a proforma.
+
+# These two variables need to be declared here (and not within do_strain_proforma)
+# if there are any field-specific subroutines (at the bottom of this file) for this particular proforma.
+my $hash_entries;						# Number of elements in hash list.
+my $primary_symbol_list;						# Reference to dehashed data from primary symbol field
+
+sub do_strain_proforma ($$)
+{
+# Process a strain proforma, the text of which is in the second argument, which has been read from the file
+# named in the first argument.
+
+    ($file, $proforma) = @_;
+    %proforma_fields = ();
+	%dup_proforma_fields = ();
+
+# The primary proforma field (that which contains the valid symbol) defines the number of expected symbols in a hash list.
+
+    $proforma =~ /!.? SN1a\..*? :(.*)/;		# Get data, if any
+    {
+	no warnings;				# split in scalar context raises deprecation warning.
+	$hash_entries = split / \# /, $1;		# Count number of symbols in primary proforma field
+    }
+
+    $primary_symbol_list = ['Missing_primary_symbol_data'];	# Set a default so that other checks don't fail with undef value.
+# only require line below if species abbreviation is included primary symbol
+#	my $primary_species_list = ['Missing_primary_symbol_data'];	# Set a default so that other checks don't fail with undef value.
+
+	$change_count = 0;
+
+
+
+# the arrays below store data returned by process_field_data (or equivalent),
+# so are dehashed, but have NOT been split on \n
+# since they are only required within  the do_strain_proforma subroutine,
+# no need to declare at the top of the file. e.g.
+#	my @MA4_list = ();
+#   etc.
+
+	my @primary_id_list = ();
+    	my @SN1c_list = ();
+    	my @SN2a_list = ();
+    	my @SN2c_list = ();
+    	my @SN1d_list = ();
+    	my @SN1e_list = ();
+	my @SN1f_list = ();
+
+FIELD:
+    foreach my $field (split (/\n!/, $proforma))
+    {
+	if ($field =~ /^(.*?)\s+(SN1a)\..*? :(.*)/s)
+	{
+	    my ($change, $code, $data) = ($1, $2, $3);
+
+	    check_dups ($file, $code, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+	    check_non_utf8 ($file, $2, $3);
+	    check_non_ascii ($file, $2, $3);
+
+# If the primary proforma field does not pass the basic test that it
+# is not empty AND contains a single line of data
+# return and do not try to check the remaining fields.
+# The $want_next variable is set to that expected next after this
+# proforma type, to make sure that the next proforma will be checked
+# (this is technically only required for those proformae that have
+# child proformae nested under them e.g. gene->allele, aberration->balancer
+# but put it in all primary profomra fields, in case the $want_next
+# requirements for others change at a later date, to be safe).
+
+		unless (contains_data ($file, $code, $data, $proforma_fields{$code}) && single_line ($file, $code, $data, $proforma_fields{$code})) {
+			$want_next = $fsm{'STRAIN'};
+			return;
+		}
+
+		($primary_symbol_list, undef) = validate_primary_proforma_field ($file, $code, $change, $hash_entries, $data, \%proforma_fields);
+
+
+	}
+	elsif ($field =~ /^(.*?)\s+(SN1b)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		check_non_utf8 ($file, $2, $3);
+		check_non_ascii ($file, $2, $3);
+		unless (double_query ($file, $2, $3)) {
+			@primary_id_list = validate_primary_FBid_field ($file, $2, $hash_entries, $1, $3, $proforma_fields{$2});
+		}
+	}
+	
+	elsif ($field =~ /^(.*?)\s+(SN1c)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		@SN1c_list = process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+
+	elsif ($field =~ /^(.*?)\s+(SN1f)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		@SN1f_list = process_field_data ($file, $hash_entries, $1, '0', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN1g)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN2a)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		@SN2a_list = process_field_data ($file, $hash_entries, $1, '0', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN2b)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN2c)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		@SN2c_list = process_field_data ($file, $hash_entries, $1, '0', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN1d)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		check_non_utf8 ($file, $2, $3);
+		check_non_ascii ($file, $2, $3);
+		no_hashes_in_proforma ($file, $2, $hash_entries, $3);
+		unless (double_query ($file, $2, $3)) {
+			@SN1d_list = validate_rename ($file, $2, $hash_entries, $1, $3, $proforma_fields{$2});
+		}
+	}
+	elsif ($field =~ /^(.*?)\s+(SN1e)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		check_non_utf8 ($file, $2, $3);
+		check_non_ascii ($file, $2, $3);
+		no_hashes_in_proforma ($file, $2, $hash_entries, $3);
+		unless (double_query ($file, $2, $3)) {
+			@SN1e_list = validate_merge_using_ids ($file, $2, $hash_entries, $1, $3, $proforma_fields{$2});
+		}
+
+	}
+	elsif ($field =~ /^(.*?)\s+(SN3a)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		check_non_utf8 ($file, $2, $3);
+		unless (double_query ($file, $2, $3)) {
+			validate_obsolete ($file, $1, $2, $3, \%proforma_fields);
+		}
+
+	}
+	elsif ($field =~ /^(.*?)\s+(SN3b)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		check_non_utf8 ($file, $2, $3);
+		double_query ($file, $2, $3) or validate_dissociate ($file, $1, $2, $3,  \%proforma_fields);
+	}
+
+	elsif ($field =~ /^(.*?)\s+(SN12)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN4)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5a)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5b)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5c)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5d)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5e)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN5f)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN6g)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN15b)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN14)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN13)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9a)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9d)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9e)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9f)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '1');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9f)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+	elsif ($field =~ /^(.*?)\s+(SN9g)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
+	}
+
+	elsif ($field =~ /^(.*?)\s+(SN6a|SN6b|SN6c|SN6d)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		process_field_data ($file, $hash_entries, $1, '0', $2, $3, \%proforma_fields, '0');
+		validate_stub ($file, $1, $2, $3);
+	}
+
+
+# fields that are not checked at all yet - validate_stub used to prevent false-positive
+# 'Invalid proforma field' message.  Remember to take field codes out of second set of ()
+# if checking for the field is implemented.
+	elsif ($field =~ /^(.*?)\s+(SN6e|SN6f|SN15a|SN16a|SN16b|SN7a|SN7b|SN7c|SN8a|SN8b|SN8c|SN8d|SN9b|SN9c|SN10a|SN10b|SN10c|SN11a|SN11b|SN11c|SN11d|SN11e|SN11f|SN11g|SN11h|SN11i)\..*? :(.*)/s)
+	{
+		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
+		validate_stub ($file, $1, $2, $3);
+	}
+
+	elsif ($field =~ /^(.*?)\s+SN(.+?)\..*?:(.*)$/s)
+	{
+	    report ($file, "Invalid proforma field\n!%s", $field);
+	} elsif ($field =~ /.*SN.*/s) {
+
+		unless ($field =~ /END OF RECORD FOR THIS PUBLICATION/s) {
+		    report ($file, "Malformed proforma field  (message tripped in strain.pl).\nThis is often caused by the line of !!! before the PROFORMA line below ending with a space (here is a line to help find that case):\n!!!!!!! \n!\n(if that does not work and you think there is nothing wrong with this line let Gillian know as it might indicate a bug with the format of the field-specific regular expressions in Peeves):\n'!%s'", $field);
+		}
+	}
+    }
+
+### Start of tests that can only be done after parsing the entire proforma. ###
+
+	check_presence ($file, \%proforma_fields, \@inclusion_essential, $primary_symbol_list);
+
+# no !c in other fields if merge field is filled in
+	plingc_merge_check ($file, $change_count,'SN1e', \@SN1e_list, $proforma_fields{'SN1e'});
+
+# rename and merge fields must not both contain data.
+
+	rename_merge_check ($file, 'SN1d', \@SN1d_list, $proforma_fields{'SN1d'}, 'SN1e', \@SN1e_list, $proforma_fields{'SN1e'});
+
+# basic cross-checks between primary and action fields for harvard-style proformae
+
+	cross_check_harv_style_symbol_rename_merge_fields ($file, 'SN', $hash_entries, \@primary_id_list, $primary_symbol_list, \@SN1d_list, \@SN1e_list, \%proforma_fields);
+
+# cross-checks for full name change fields
+	compare_field_pairs ($file, $hash_entries, 'SN2c', \@SN2c_list, 'SN2a', \@SN2a_list, \%proforma_fields, 'dependent', 'not same');
+
+	compare_field_pairs ($file, $hash_entries, 'SN1e', \@SN1e_list, 'SN2c', \@SN2c_list, \%proforma_fields, 'single', '');
+
+
+# check that valid symbol is in the symbol synonym field when !c-ing it under the  'unattributed' pub.
+# Only do the check if the symbol synonym field contains some data
+if ($unattributed && $#SN1c_list + 1 == $hash_entries) {
+
+	check_unattributed_synonym_correction ($file, $hash_entries, 'SN1a', $primary_symbol_list, 'SN1c', \@SN1c_list, \%proforma_fields, "You must include the valid symbol in SN1c when \!c-ing it under the 'unnattributed' publication.");
+
+}
+
+check_filled_in_for_new_feature ($file, 'SN1f', $hash_entries, \@SN1f_list, \@primary_id_list, \@SN1d_list, \@SN1e_list, \%proforma_fields, 'only');
+
+
+
+### End of tests that can only be done after parsing the entire proforma. ###
+
+# The following line must always be at the bottom of the do proforma subroutine
+
+    $want_next = $fsm{'STRAIN'};
+}
+
+### add any proforma field-specific subroutines here (or better still add to or use
+### generic subroutines in tools.pl
+
+
+
+
+
+1;				# Standard boilerplate.

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -1057,10 +1057,8 @@ my $dv_short_qualifiers = {
     set_symbol ('dg', 'cur_type', 'CAMCUR');
     set_symbol ('gm', 'cur_type', 'CAMCUR');
     set_symbol ('sm', 'cur_type', 'CAMCUR');
-    set_symbol ('vt', 'cur_type', 'CAMCUR');
     set_symbol ('ga', 'cur_type', 'GOCUR');
     set_symbol ('ha', 'cur_type', 'GOCUR');
-    set_symbol ('pg', 'cur_type', 'GOCUR');
     set_symbol ('up', 'cur_type', 'GOEXT');
     set_symbol ('pl', 'cur_type', 'BIBLIO');
     set_symbol ('as', 'cur_type', 'USER');
@@ -1076,6 +1074,7 @@ my $dv_short_qualifiers = {
     set_symbol ('pt', 'cur_type', 'AUTO');
     set_symbol ('tl', 'cur_type', 'UNMCUR');
 
+    set_symbol ('rs', 'cur_type', 'CAMCUR');
 
 #  Curator shortcuts are integers or abbreviations which translate into proforma-dependent strings on parsing.
 #  Peeves doesn't care about their values, only their validity, but the translations are given here so that
@@ -7214,6 +7213,7 @@ my $dv_short_qualifiers = {
 # fields that can only contain 'n'
 	set_symbol ('negative', 'current_value', 'n');
 	set_symbol ('SN1g_value', 'current_value', 'wild type');
+
 	
 # allowed value for IN2b, plus double check its still a current psi-mi term
 	set_symbol ('IN2b_value', 'current_value', 'physical association');

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -7213,6 +7213,7 @@ my $dv_short_qualifiers = {
 	set_symbol ('positive', 'current_value', 'y');
 # fields that can only contain 'n'
 	set_symbol ('negative', 'current_value', 'n');
+	set_symbol ('SN1g_value', 'current_value', 'wild type');
 	
 # allowed value for IN2b, plus double check its still a current psi-mi term
 	set_symbol ('IN2b_value', 'current_value', 'physical association');
@@ -7271,6 +7272,10 @@ my $dv_short_qualifiers = {
 		valid_symbol ($term, 'SO:default') or print "MAJOR PEEVES ERROR in basic ontology processing: the '$term' term listed in Peeves as an allowed value for SO terms attached to gene symbols in G38 is no longer a valid SO term, Peeves will need altering to cope (probably by replacing this obsolete term with a new valid one).\n\n";
 
 	}
+# allowed values for the SN9f field
+
+    set_symbol ('isofemale line', 'SN9f_value', 1);
+    set_symbol ('multi-female line', 'SN9f_value', 1);
 
 
 # Assays for TAP statements - would be lovely if these were in an ontology, but Harvard appears to be reluctant, so here they are. Full definitions included where available ;P). For now there is nothing but general typing ('assay'). In future this should probably be further subdivided to allow checking that assay is appropriate to gene product type. The assay name is stored as a value, but is not actually used except to return 'true' as of 111028 (DOS).

--- a/production/tools.pl
+++ b/production/tools.pl
@@ -1524,6 +1524,8 @@ sub check_allowed_characters {
 
 		'SF1a' => 'a-zA-Z0-9_:;&\[\]\()\'\.\+\-\/', # same as LC1a, but with / added (DC-895)
 
+		'SN1a' => 'a-zA-Z0-9:;&\\\.\-\'', # same characters as G1a, except no [ ] ( )
+
 #		'' => '',
 
 # name fields
@@ -1532,6 +1534,7 @@ sub check_allowed_characters {
 		'A2a' => 'a-zA-Z0-9:;&\[\]\()\'\.,\+/ \?\-', # same characters as for G2a plus ?
 		'AB2a' => 'a-zA-Z0-9:;&\[\]\()\'\.,\+/ \-', # same characters as for G2a
 		'GG2a' => 'a-zA-Z0-9:;&\[\]\()\'\.,\+/ \-', # same characters as for G2a
+		'SN2a' => 'a-zA-Z0-9:;&\\\.\-\' ', # same characters as SN1a, plus space
 
 		'TO2a' => 'a-zA-Z0-9:;&\[\]\()\'\.,\+/ \-', # same characters as for G1a, EXCEPT no \ (has [ ] to allow for things like Ca[2+]-channel). Has in addition , + / and space
 
@@ -1560,7 +1563,7 @@ sub check_allowed_characters {
 
 	unless (exists $mapping_table{$code}) {
 
-		report ($file,"%s proforma has not been set up to check for valid characters in symbol - please let Gillian know if you see this error, so that it can be set up properly",$code);
+		report ($file,"%s proforma field has not been set up to check for valid characters in symbol - please let Gillian know if you see this error, so that it can be set up properly",$code);
 		return;
 	}
 
@@ -2517,6 +2520,15 @@ sub check_valid_symbol_field {
 
 		'MS23' => ['FBal'],
 
+		'SN4' => ['FBsn'],
+		'SN5a' => ['FBal'],
+		'SN5b' => ['FBal'],
+		'SN5c' => ['FBab'],
+		'SN5d' => ['FBab'],
+		'SN5e' => ['FBti'],
+		'SN5f' => ['FBti'],
+		'SN14' => ['FBlc'],
+
 	);
 
 	unless ($allowed_types{$code}) {
@@ -3292,6 +3304,9 @@ sub check_single_allowed_value {
 
 		'GA30f' => 'negative',
 
+		'SN1g' => 'SN1g_value',
+		'SN9e' => 'positive',
+
 	);
 
 	
@@ -3320,6 +3335,7 @@ sub validate_species_abbreviation_field {
 
 		'MA20' => 'drosophilid',
 		'TC1d' => 'drosophilid',
+		'SN1f' => 'drosophilid',
 
 
 
@@ -3864,6 +3880,10 @@ sub validate_cvterm_field {
 		'GA30d' => ['FBcv:experimental_tool_descriptor'],
 		'MS14d' => ['FBcv:experimental_tool_descriptor'],
 		'G40' => ['FBcv:experimental_tool_descriptor'],
+
+		'SN9a' => ['chromosome'],
+		'SN9d' => ['chromosome'],
+		'SN9f' => ['SN9f_value'],
 
 	);
 


### PR DESCRIPTION
**1. change v.2.50 adds checking for the strain proforma.**

**new files/folders:**

Documentation:
- doc/current_status/strain.within_field _overview of checking status for proforma_
- doc/current_status/strain.between_field _overview of checking status for proforma_
- files in doc/specs/strain _detailed specs of checking for each proforma field_

Code:
- production/strain.pl _main code for checking strain proforma fields_

**modified files**

Code:
- production/Peeves

      lines 893-928 code specifying the checking subroutine used for each strain.pro field
      lines 354-360 code specifying the action fields for strain.pro (as is not standard Harvard type)
      other changes add info required to use strain.pl and carry out checking

- production/tools.pl
      - lines 2523-2530  code specifying the type of symbol expected in corresponding proform field
      - lines 3884-3886, 3307, 3308 code specifying the type of cvterm of canned comment expected in corresponding proform field

**2. change v.2.51 updates curator information in symtab.pl**
