### PR TITLE
changes for versions 2.72 thru 2.75 (DC-1071 and two small other edits)

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -1007,5 +1007,11 @@ our $Peeves_version = "2.67"; #  change moseg.pro symbol fields to check_valid_c
 our $Peeves_version = "2.68.1"; #  add check_for_rename_across_species (DC-536): added for Cambridge style proformae (also fixed bug in get_species_prefix_from_symbol)
 # 8.4.2024
 our $Peeves_version = "2.69"; #  Add check for malformed proforma header lines (DC-1067)
+# 12.4.2024
+our $Peeves_version = "2.70"; #  making sure curators get message not to use 'in vitro construct - RNAi' until it is obsoleted (related to DC-1071)
 # 17.4.2024
 our $Peeves_version = "2.71"; #  add check to warn if OMIM: used in free text (DC-1065)
+# 29.4.2024
+our $Peeves_version = "2.72"; #  remove temp messages about child 'in vitro construct - X' terms now that they are obsolete (DC-1071)
+our $Peeves_version = "2.73"; #  adding more possible causes to 'Found proforma of unexpected type' warning.
+our $Peeves_version = "2.75"; #  fixing bug in G35 checking (removing overly stringent false-positive message) (related to DC-417).

--- a/doc/specs/allele/GA8.txt
+++ b/doc/specs/allele/GA8.txt
@@ -33,8 +33,6 @@ checks within field (in validate_cvterm_field):
 * each value must be valid term (i.e. does not have is_obsolete: true) from
 flybase_controlled_vocabulary.obo, and the term must be in the 'origin_of_mutation' namespace 
 
-* If the term used is a child of 'in vitro construct' (EXCEPT 'in vitro construct - RNAi') warns that the child term is now deprecated (now that we are curating GA35 field) and reminds to use 'in vitro construct' instead. (This check can be removed once the child terms now 'replaced' by GA35 curation have been removed from the ontology, but they need to be kept in place in chado for now until retrofit for GA35 has been done, and any relevant derivation scripts have all been updated, so adding this warning for now rather than removed the terms from the ontology immediately).
-
 
 Checks between fields (done at end of proforma parsing)
 
@@ -61,4 +59,4 @@ doc: doc reflects what has been implemented
 
 ### Updated:
 
-gm211206.
+gm240429.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.71"; #  add check to warn if OMIM: used in free text (DC-1065)
+our $Peeves_version = "2.75"; #  fixing bug in G35 checking (removing overly stringent false-positive message) (related to DC-417).
 
 =head2 Version
 
@@ -1410,7 +1410,7 @@ init_symbol_table ($Peeves_version, $pcfg, $ccfg);
 	    }
 	    else
 	    {
-		report ($file, "*CRITICAL ERROR* Found proforma of unexpected type '%s'. You may have missed out a 'parent' proforma (e.g. ALLELE needs to be under a GENE) or got proformae in the wrong order. This could have have VERY bad consequences when loading, please check and *DO NOT LOAD* this curation record until this message disappears.",
+		report ($file, "*CRITICAL ERROR* Found proforma of unexpected type '%s'. You may have missed out a 'parent' proforma (e.g. ALLELE needs to be under a GENE), got proformae in the wrong order, or an odd (likely invisible) character may have crept into your proforma template if you are not using the standard svn proforma templates. If the problem is due to an odd character, Peeves will not have checked any of the proforma fields after the line that tripped this message. In addition, missing out a parent proforma can have VERY bad consequences when loading. So please check and *DO NOT LOAD* this curation record until this message disappears.",
 			$type);
 	    }
 

--- a/production/gene.pl
+++ b/production/gene.pl
@@ -683,12 +683,6 @@ compare_field_pairs ($file, $g_num_syms, 'G2c', \@G2c_list, 'G2a', \@G2a_list, \
 
 							}
 
-							unless ($G35_data) {
-
-								report ($file, "%s must be filled in for a new non-drosophilid gene.\n!%s\n", "G35", $proforma_fields{'G1a'});
-
-							}
-
 						}
 					}
 				}

--- a/production/symtab.pl
+++ b/production/symtab.pl
@@ -916,25 +916,12 @@ my $dv_short_qualifiers = {
  	my $fbcv_ancestors = {
  		'modifier of variegation' => '1',
 		'increased mortality during development' => '1',
-## the following is stored as a temporary measure, until the 'in vitro construct - X' terms can be obsoleted in the ontology. The stored values are used in validate_cvterm_field (tools.pl) to remind curators that most child 'in vitro construct - X' terms are no longer used for the GA8 field, and that the parent term should be used instead. The value of the key below is '0' NOT '1' which prevents the parent term being stored
-## once terms are removed from ontology, the line below can be removed
-		'in vitro construct' => '0',
 		'split system combination' => '1', # for validation of F3 for FBco
 		'split system component' => '1', # for validation that components of combination symbol are split system components
 	};
 
 	&process_ontology_file ($FBcv_obo, 'FBcv:\d{1,}', '1', $fbcv_ancestors);
 
-
-## removing 'in vitro construct - RNAi' from the list of 'in vitro construct' descendents as this IS still needed to be used in GA8. Once child terms are removed from ontology, the section below can be removed
-
-	if (valid_symbol ('in vitro construct - RNAi', 'FBcv:in vitro construct')) {
-
-		delete_symbol ('in vitro construct - RNAi', 'FBcv:in vitro construct');
-
-	}
-
-##
 
 
 # adding list of allowed qualifers for phenotypic_class to symbol table

--- a/production/tools.pl
+++ b/production/tools.pl
@@ -3959,13 +3959,7 @@ sub validate_cvterm_field {
 
 				valid_symbol ($datum, "SO:incomplete_transcript_variant") and report ($file, "%s: '%s' is not valid for this field%s:\n!%s", $code, $datum, " (it is from the incomplete_transcript_variant branch). This branch of SO describes variants in 'an incompletely *annotated* transcript' and this definition is not applicable to transgenic product class", $context->{$code});
 
-## message to remind curators to use parent 'in vitro construct' term in most cases now we are curating GA35
-			} elsif ($code eq 'GA8') {
-
-				valid_symbol ($datum, 'FBcv:in vitro construct') and report ($file, "%s: '%s' is deprecated for this field now that we are using GA35, use 'in vitro construct' instead:\n!%s", $code, $datum, $context->{$code});
-
 			}
-
 
 		} else {
 

--- a/records2test/DC-417/gm1.edit
+++ b/records2test/DC-417/gm1.edit
@@ -1,0 +1,63 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0199194
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Dsuz\newgene
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :n
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :protein_coding_gene ; SO:0001217
+! G2a.  Action - gene name to use in FlyBase                *e :
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :
+! G26.  Foreign gene summary information             *u :
+! G35.  Reference database ID for foreign sequence          :
+! G40. Commonly used as experimental tool [CV] :
+! G15.  Internal notes  *W :??new non-Dmel drosophilid gene, should not generate error messages
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Ecol\new
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :n
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :engineered_foreign_gene ; SO:0000281
+! G2a.  Action - gene name to use in FlyBase                *e :
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :
+! G26.  Foreign gene summary information             *u :Foreign sequence; species == Escherichia coli; gene == 'new'.
+! G35.  Reference database ID for foreign sequence          :
+! G40. Commonly used as experimental tool [CV] :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/broken_harv_record/258624.tl.skim.240402
+++ b/records2test/broken_harv_record/258624.tl.skim.240402
@@ -1,0 +1,161 @@
+! C1.  Curator ID	:tl
+! C2.  Date		:240402
+! C3.  Curator notes to self	:New Functional Motifs for the Targeted Localization of Proteins to the Nucleolus in Drosophila and Human Cells. 
+! C9.  Cambridge curation (new_al, merge, split, rename, new_char, pheno, nocur, new_transg, gene_group, pheno_chem, pheno_anat) 
+! C4.  Additional curation (P41. wt_exp, pert_exp, neur_exp, gene_model, gene_model_nonmel, phys_int, cis_reg, genom_feat, no_flag, disease, diseaseHP, dataset, cell_line, dataset, P42. novel_anat, P43. disease)
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"            *U   :FBrf0258624
+! P2.   Parent multipub abbreviation                    *w   :Int. J. Mol. Sci.
+! P40.  Flag Cambridge for curation                 CAMCUR   :
+! P41.  Flag Harvard for curation                  HARVCUR   :cell_line??
+! P42.  Flag Ontologists for curation                 ONTO   :
+! P43.  Flag Disease for curation                  DISEASE   :
+! P44.  Disease(s) relevant to FBrf            [free text]   :
+! P19.  Internal notes                                    *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Non3
+! G1b.  Gene symbol(s) used in reference                    *i   :Non3??
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Ns3
+! G1b.  Gene symbol(s) used in reference                    *i   :NS3
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :pit
+! G1b.  Gene symbol(s) used in reference                    *i   :Pit
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :His2B
+! G1b.  Gene symbol(s) used in reference                    *i   :H2B
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Ns1
+! G1b.  Gene symbol(s) used in reference                    *i   :NS1
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :mod
+! G1b.  Gene symbol(s) used in reference                    *i   :mod
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Fib
+! G1b.  Gene symbol(s) used in reference                    *i   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :Fibrillarin
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Nph
+! G1b.  Gene symbol(s) used in reference                    *i   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :Nucleophosmin
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Nlp
+! G1b.  Gene symbol(s) used in reference                    *i   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :Nucleoplasmin
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Nopp140
+! G1b.  Gene symbol(s) used in reference                    *i   :Nopp140
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Ns2
+! G1b.  Gene symbol(s) used in reference                    *i   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :Nucleostemin2
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :nop5
+! G1b.  Gene symbol(s) used in reference                    *i   :Nop5
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 77:  01 Jun 2016
+!
+! G1a.  Gene symbol to use in FlyBase                       *a   :Act5C
+! G1b.  Gene symbol(s) used in reference                    *i   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)    :y
+! G2b.  Gene name(s) used in reference                      *V   :Actin 5C
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t   :
+! G34.  Antibody generated (monoclonal/polyclonal)          *s   :
+! G15.  Internal notes  *W :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/broken_harv_record/FBhh0001572.sian.hh_9.240403
+++ b/records2test/broken_harv_record/FBhh0001572.sian.hh_9.240403
@@ -1,0 +1,124 @@
+! C1.  Curator ID    :sian
+! C2.  Date        :240403
+! C3.  Curator notes to self    :This curation record has somehow ended up with an odd character (which appeared in BBEdit Find as \x{A0}) which had crept into a lot of the proforma headers and fields in that record after spaces. This was breaking Peeves so that it was ignoring all the publication proformae. This was generating the following kind of Peeves error, indicating that it was v. unhappy:
+
+FBhh0001572.sian.hh_9.240403: *CRITICAL ERROR* Found proforma of unexpected type 'HUMAN HEALTH MODEL'. You may have missed out a 'parent' proforma (e.g. ALLELE needs to be under a GENE) or got proformae in the wrong order. This could have have VERY bad consequences when loading, please check and *DO NOT LOAD* this curation record until this message disappears.
+
+This is because Peeves expects either a publication/multipub proforma at the top of the record which it was not finding.
+
+The problem was the odd characters in the PUBLICATION PROFORMA header line - removing the odd character solely from those lines (as in FBhh0001572.sian.hh_fixed.240403 in the same folder) fixed the problem. I think its slightly more complex than that though as 258624.tl.skim.24042 in the same folder also has these odd characters in, but Peeves appears to be coping and chopping up the proformae correctly.
+
+So its probably something to do with the fact that this hh one has just the header line and a single field (as the 258624.tl.skim.24042 record has additional publication fields)
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA                  Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0259040
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA                  Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222196
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+! HH1e. Additional synonyms (free text)   :MPS 3C
+MPS III C
+MPS3C
+Mucopoly-saccharidosis type 3C
+Mucopolysaccharidosis type IIIC (Sanfilippo C)
+Acetyl-CoA: heparan-alpha-D-glucosaminide N-acetyltransferase deficiency
+Heparan-alpha-glucosaminide acetyltransferase deficiency
+!
+! HH1g. Sub-datatype [disease, health-related process] : 
+! HH2a. Category [parent entity, sub-entity, specific entity, group entity] :
+! HH2b. Parent entity (if HH2a = sub-entity)  :
+!
+! HH2d. DOID (with DOID prefix) :DOID:0111393
+!
+! HH3a. Action - rename this disease (HH1b is rename)  :
+! HH3c. Action - delete disease record ("y"/blank)  :
+!
+! HH15. Overview of Drosophila model (free text)  :This report describes mucopolysaccharidosis type IIIC, a subtype of progeria that exhibits autosomal recessive inheritance. The human gene implicated is HGSNAT, which encodes heparan-alpha-glucosaminide N-acetyltransferase, one of several enzymes involved in the lysosomal degradation of heparin sulfate. There is one high-scoring fly ortholog, Dmel\@Hgsnat@, for which multiple genetic reagents, including classical alleles, RNAi-targeting constructs, and alleles caused by insertional mutagenesis, have been generated. 
+
+Human HGSNAT has not been introduced into flies.
+
+Flies mutant for @Hgsnat@ exhibit a progressive accumulation of heparin sulfuate; this is also observed in flies undergoing ubiquitous RNAi-mediated knockdown of Dmel\@Hgsnat@. Ubiquituous RNAi-mediated knockdown also results in a significantly shortened lifespan. Pan-neuronal RNAi-mediated knockdown of Dmel\@Hgsnat@ results in enlargement of the endolysosomal compartment in the brain, presynaptic abnormalities, and locomotor defects. RNAi-mediated knockdown of Dmel\@Hgsnat@ in cortex and wrapping glia resulted in climbing defects in adult flies, while knockdown in sub-perineurial glia and astrocytes impaired activity in an activity monitor assay.
+
+[updated Apr. 2024 by FlyBase; FBrf0222196]
+!
+! HH4h. Description of process (free text) :
+! HH4a. Description/Symptoms and phenotype (free text)  :Mucopolysaccharidosis type III (MPS III) is a multisystem lysosomal storage disease characterized by progressive central nervous system degeneration manifest as severe intellectual disability (ID), developmental regression, and other neurologic manifestations including autism spectrum disorder (ASD), behavioral problems, and sleep disturbances. Disease onset is typically before age ten years. Disease course may be rapidly or slowly progressive; some individuals with an extremely attenuated disease course present in mid-to-late adulthood with early-onset dementia with or without a history of ID. Systemic manifestations can include musculoskeletal problems (joint stiffness, contractures, scoliosis, and hip dysplasia), hearing loss, respiratory tract and sinopulmonary infections, and cardiac disease (valvular thickening, defects in the cardiac conduction system). Neurologic decline is seen in all affected individuals; however, clinical severity varies within and among the four MPS III subtypes (defined by the enzyme involved) and even among members of the same family. Death usually occurs in the second or third decade of life secondary to neurologic regression or respiratory tract infections. [from GeneReviews, Mucopolysaccharidosis Type III; 2024.04.03]
+! HH4b. Description/Genetics (free text)  :
+! HH4c. Description/Cellular phenotype and pathology (free text)  :
+! HH4g. Description/Molecular information (free text)  :
+! HH4f. Related human health entity :FBhh0000851
+!
+! HH5a. External link - accession number (repeat for multiple ) :mucopolysaccharidosis-type-iii
+!      HH5b. External link - FB database ID (DB1a) :GHR_condition
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis type III
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :hgsnat
+!      HH5b. External link - FB database ID (DB1a) :GHR_gene
+!      HH5c. External link - title/description of specific accession :HGSNAT gene heparan-alpha-glucosaminide N-acetyltransferase
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :NBK546574
+!      HH5b. External link - FB database ID (DB1a) :Gene_reviews
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis Type III
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :39477 
+!      HH5b. External link - FB database ID (DB1a) :Medgene
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis, MPS-III-C(MPS3C)
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA                  Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222195
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+!
+! HH7a. Human gene(s) implicated (FB symbol, Hsap\xxx) :
+! HH7e. Human gene(s) implicated (HGNC accession number; with HGNC prefix) :HGNC:26527
+!      HH7d. Orthologous Dmel gene(s) [usu. DIOPT] :Hgsnat
+!      HH7c. Comments on ortholog relationships (free text) :One to one (1 human to 1 Drosophila); HGSNAT has one high-scoring Drosophila ortholog, @Hgsnat@.
+!      HH7f. Action - dissociate accession specified in HH7e from this human health model (blank/y) :
+!
+! HH8a. Dmel gene(s) implicated (repeat for multiple) :Hgsnat
+!      HH8c. Comments on orthologs (free text) :High-scoring ortholog of human HGSNAT (1 Drosophila to 1 human).
+!      HH8d. Action - dissociate gene specified in HH8a from this human health model (blank/y) :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA                  Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222197
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+! HH1e. Additional synonyms (free text)   :MPS IIIC
+Sanfilippo syndrome C
+Acetyl-CoA:Alpha-Glucosaminide n-acetyltransferase deficiency
+! HH2c. OMIM phenotype number (number only) :252930
+!
+! HH3d. Action - dissociate HH1f from FBrf ("y"/blank)  :
+!
+! HH4a. Description/Symptoms and phenotype (free text)  :Sanfilippo syndrome comprises several forms of lysosomal storage diseases due to impaired degradation of heparan sulfate. The deficient enzyme in Sanfilippo syndrome C, or MPS IIIC, is an acetyltransferase that catalyzes the conversion of alpha-glucosaminide residues to N-acetylglucosaminide in the presence of acetyl-CoA. [from OMIM:252930; 2024.04.03]
+! HH4b. Description/Genetics (free text)  :Mucopolysaccharidosis type IIIC (MPS3C), also known as Sanfilippo syndrome C, is caused by homozygous or compound heterozygous mutation in the HGSNAT gene, encoding heparan acetyl-CoA:alpha-glucosaminide N-acetyltransferase, on chromosome 8p11. [from OMIM:252930; 2024.04.03]
+! HH4c. Description/Cellular phenotype and pathology (free text)  :
+! HH4g. Description/Molecular information (free text)  :
+! HH20. Internal notes :OMIM section
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/broken_harv_record/FBhh0001572.sian.hh_fixed.240403
+++ b/records2test/broken_harv_record/FBhh0001572.sian.hh_fixed.240403
@@ -1,0 +1,116 @@
+! C1.  Curator ID    :sian
+! C2.  Date        :240403
+! C3.  Curator notes to self    :This curation record was made from FBhh0001572.sian.hh_9.240403 which had an odd character (which appeared in BBEdit Find as \x{A0}) which had crept into a lot of the proforma headers and fields in that record after spaces and was breaking peeves). In this version, I removed the odd character from within the PUBLICATION PROFORMA header field in each case - that fixed it so it is now correctly checked by Peeves.
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA         Version 48: 21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0259040
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA         Version 48: 21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222196
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+! HH1e. Additional synonyms (free text)   :MPS 3C
+MPS III C
+MPS3C
+Mucopoly-saccharidosis type 3C
+Mucopolysaccharidosis type IIIC (Sanfilippo C)
+Acetyl-CoA: heparan-alpha-D-glucosaminide N-acetyltransferase deficiency
+Heparan-alpha-glucosaminide acetyltransferase deficiency
+!
+! HH1g. Sub-datatype [disease, health-related process] : 
+! HH2a. Category [parent entity, sub-entity, specific entity, group entity] :
+! HH2b. Parent entity (if HH2a = sub-entity)  :
+!
+! HH2d. DOID (with DOID prefix) :DOID:0111393
+!
+! HH3a. Action - rename this disease (HH1b is rename)  :
+! HH3c. Action - delete disease record ("y"/blank)  :
+!
+! HH15. Overview of Drosophila model (free text)  :This report describes mucopolysaccharidosis type IIIC, a subtype of progeria that exhibits autosomal recessive inheritance. The human gene implicated is HGSNAT, which encodes heparan-alpha-glucosaminide N-acetyltransferase, one of several enzymes involved in the lysosomal degradation of heparin sulfate. There is one high-scoring fly ortholog, Dmel\@Hgsnat@, for which multiple genetic reagents, including classical alleles, RNAi-targeting constructs, and alleles caused by insertional mutagenesis, have been generated. 
+
+Human HGSNAT has not been introduced into flies.
+
+Flies mutant for @Hgsnat@ exhibit a progressive accumulation of heparin sulfuate; this is also observed in flies undergoing ubiquitous RNAi-mediated knockdown of Dmel\@Hgsnat@. Ubiquituous RNAi-mediated knockdown also results in a significantly shortened lifespan. Pan-neuronal RNAi-mediated knockdown of Dmel\@Hgsnat@ results in enlargement of the endolysosomal compartment in the brain, presynaptic abnormalities, and locomotor defects. RNAi-mediated knockdown of Dmel\@Hgsnat@ in cortex and wrapping glia resulted in climbing defects in adult flies, while knockdown in sub-perineurial glia and astrocytes impaired activity in an activity monitor assay.
+
+[updated Apr. 2024 by FlyBase; FBrf0222196]
+!
+! HH4h. Description of process (free text) :
+! HH4a. Description/Symptoms and phenotype (free text)  :Mucopolysaccharidosis type III (MPS III) is a multisystem lysosomal storage disease characterized by progressive central nervous system degeneration manifest as severe intellectual disability (ID), developmental regression, and other neurologic manifestations including autism spectrum disorder (ASD), behavioral problems, and sleep disturbances. Disease onset is typically before age ten years. Disease course may be rapidly or slowly progressive; some individuals with an extremely attenuated disease course present in mid-to-late adulthood with early-onset dementia with or without a history of ID. Systemic manifestations can include musculoskeletal problems (joint stiffness, contractures, scoliosis, and hip dysplasia), hearing loss, respiratory tract and sinopulmonary infections, and cardiac disease (valvular thickening, defects in the cardiac conduction system). Neurologic decline is seen in all affected individuals; however, clinical severity varies within and among the four MPS III subtypes (defined by the enzyme involved) and even among members of the same family. Death usually occurs in the second or third decade of life secondary to neurologic regression or respiratory tract infections. [from GeneReviews, Mucopolysaccharidosis Type III; 2024.04.03]
+! HH4b. Description/Genetics (free text)  :
+! HH4c. Description/Cellular phenotype and pathology (free text)  :
+! HH4g. Description/Molecular information (free text)  :
+! HH4f. Related human health entity :FBhh0000851
+!
+! HH5a. External link - accession number (repeat for multiple ) :mucopolysaccharidosis-type-iii
+!      HH5b. External link - FB database ID (DB1a) :GHR_condition
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis type III
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :hgsnat
+!      HH5b. External link - FB database ID (DB1a) :GHR_gene
+!      HH5c. External link - title/description of specific accession :HGSNAT gene heparan-alpha-glucosaminide N-acetyltransferase
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :NBK546574
+!      HH5b. External link - FB database ID (DB1a) :Gene_reviews
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis Type III
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+! HH5a. External link - accession number (repeat for multiple ) :39477 
+!      HH5b. External link - FB database ID (DB1a) :Medgene
+!      HH5c. External link - title/description of specific accession :Mucopolysaccharidosis, MPS-III-C(MPS3C)
+!      HH5d. Action - dissociate accession specified in HH5a/HH5b from this human health model (blank/y) :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA         Version 48: 21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222195
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+!
+! HH7a. Human gene(s) implicated (FB symbol, Hsap\xxx) :
+! HH7e. Human gene(s) implicated (HGNC accession number; with HGNC prefix) :HGNC:26527
+!      HH7d. Orthologous Dmel gene(s) [usu. DIOPT] :Hgsnat
+!      HH7c. Comments on ortholog relationships (free text) :One to one (1 human to 1 Drosophila); HGSNAT has one high-scoring Drosophila ortholog, @Hgsnat@.
+!      HH7f. Action - dissociate accession specified in HH7e from this human health model (blank/y) :
+!
+! HH8a. Dmel gene(s) implicated (repeat for multiple) :Hgsnat
+!      HH8c. Comments on orthologs (free text) :High-scoring ortholog of human HGSNAT (1 Drosophila to 1 human).
+!      HH8d. Action - dissociate gene specified in HH8a from this human health model (blank/y) :
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PUBLICATION PROFORMA         Version 48: 21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0222197
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! HUMAN HEALTH MODEL PROFORMA   Version 2.1:  23 Aug 2019
+!
+! HH1f. Database ID for disease or health issue  :FBhh0001572
+! HH1b. Full name to use in database  :mucopolysaccharidosis type IIIC
+! HH1e. Additional synonyms (free text)   :MPS IIIC
+Sanfilippo syndrome C
+Acetyl-CoA:Alpha-Glucosaminide n-acetyltransferase deficiency
+! HH2c. OMIM phenotype number (number only) :252930
+!
+! HH3d. Action - dissociate HH1f from FBrf ("y"/blank)  :
+!
+! HH4a. Description/Symptoms and phenotype (free text)  :Sanfilippo syndrome comprises several forms of lysosomal storage diseases due to impaired degradation of heparan sulfate. The deficient enzyme in Sanfilippo syndrome C, or MPS IIIC, is an acetyltransferase that catalyzes the conversion of alpha-glucosaminide residues to N-acetylglucosaminide in the presence of acetyl-CoA. [from OMIM:252930; 2024.04.03]
+! HH4b. Description/Genetics (free text)  :Mucopolysaccharidosis type IIIC (MPS3C), also known as Sanfilippo syndrome C, is caused by homozygous or compound heterozygous mutation in the HGSNAT gene, encoding heparan acetyl-CoA:alpha-glucosaminide N-acetyltransferase, on chromosome 8p11. [from OMIM:252930; 2024.04.03]
+! HH4c. Description/Cellular phenotype and pathology (free text)  :
+! HH4g. Description/Molecular information (free text)  :
+! HH20. Internal notes :OMIM section
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
**v.2.72**: changes to `symtab.pl,` `tools.pl` are for DC-417 (removing temporary extra messages for child terms of 'in vitro construct' now that the terms have been obsoleted)

**v.2.73**: change to `Peeves` beefs up error message for 'Found proforma of unexpected type' warning.

**v.2.75**: changes to `gene.pl `remove an overly stringent false-positive (accidently skipped v.2.74)

