### PR TITLE
v.2.76: new subroutine to cross-check that full name in rename field …

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -1015,3 +1015,5 @@ our $Peeves_version = "2.71"; #  add check to warn if OMIM: used in free text (D
 our $Peeves_version = "2.72"; #  remove temp messages about child 'in vitro construct - X' terms now that they are obsolete (DC-1071)
 our $Peeves_version = "2.73"; #  adding more possible causes to 'Found proforma of unexpected type' warning.
 our $Peeves_version = "2.75"; #  fixing bug in G35 checking (removing overly stringent false-positive message) (related to DC-417).
+# 19.6.2024
+our $Peeves_version = "2.76"; #  new subroutine to cross-check that full name in rename field is what is in chado for that object (DC-1076).

--- a/doc/current_status/experimental_tool.between_field
+++ b/doc/current_status/experimental_tool.between_field
@@ -12,7 +12,7 @@
 !
 ! TO2a.  Action - experimental tool name to use in FlyBase       :FULL
 ! TO2b.  Experimental tool name synonym(s)                       :NA
-! TO2c.  Action - rename this experimental tool name             :PARTIAL
+! TO2c.  Action - rename this experimental tool name             :FULL
 !
 ! TO4.   Experimental tool uses [CV]                             :FULL
 ! TO5.   Description of experimental tool [free text]            :FULL

--- a/doc/current_status/variant.between_field
+++ b/doc/current_status/variant.between_field
@@ -8,7 +8,7 @@
 ! AB1g.  Is AB1a the current symbol of a genotype variant in FlyBase? :FULL
 ! AB2a.  Action - genotype variant name to use in FlyBase          *e :NOT YET IMPLEMENTED
 ! AB2b.  Genotype variant name(s) used in reference                *Q :NA
-! AB2c.  Action - replace this genotype variant name                  :NOT YET IMPLEMENTED
+! AB2c.  Action - replace this genotype variant name                  :PARTIAL
 ! AB11a. Action - obsolete AB1a in FlyBase       TAKE CARE :NOT YET IMPLEMENTED
 ! AB11b. Action - dissociate AB1a from reference TAKE CARE :PARTIAL
 ! AB10.  Nickname                                            *U :NA

--- a/doc/specs/aberration/A2c.txt
+++ b/doc/specs/aberration/A2c.txt
@@ -26,6 +26,10 @@ No (Implemented)
 
 ### Checks:
 
+Cross-checks between fields:
+
+
+    * sub cross_check_full_name_rename checks that the value in G2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
 
 
 ### Related fields:
@@ -41,11 +45,9 @@ doc: checked that doc reflects what has been implemented
 
 Not implemented:
 
-* similar to G2c, there is no check that the value given in A2c is really a valid fullname in chado.
-
 * there is no cross-check of A2a with A2c - need to add something that takes into account whether or not the allele is new (A1g) and whether or not rename/merge fields (A1e/A1f) are filled in. [gm131211]
 
 
 ### Updated:
 
-gm151001.
+gm240619.

--- a/doc/specs/allele/GA2c.txt
+++ b/doc/specs/allele/GA2c.txt
@@ -32,6 +32,9 @@ Cross-checks between fields:
 
 * If GA2c and GA2a are both filled in, they must not be the same value  (compare_field_pairs, pair_test = 'not same')
 
+* sub cross_check_full_name_rename checks that the value in G2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
+
+* GA2c and GA1f must not both be filled in (compare_field_pairs, pair_test = 'single')
 
 ### Related fields:
 
@@ -44,15 +47,7 @@ Cross-checks between fields:
 
 ### Status:
 
-doc: checked that doc reflects what has been implemented
-
-Not yet implemented:
-
-* similar to G2c, there is no check that the value given in GA2c is really a valid fullname in chado.
-
-
-
 
 ### Updated:
 
-gm151001.
+gm240619.

--- a/doc/specs/experimental_tool/TO2c.txt
+++ b/doc/specs/experimental_tool/TO2c.txt
@@ -37,6 +37,8 @@ Cross-checks between fields:
 
 * If TO1g (merge field) is filled in, TO2c must not be filled in (compare_field_pairs, pair_test = 'single')
 
+* sub cross_check_full_name_rename checks that the value in TO2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
+
 
 ### Related fields:
 
@@ -50,12 +52,7 @@ Cross-checks between fields:
 ### Status:
 
 
-Not yet implemented:
-
-* there is no check that the value given in TO2c is really a valid fullname in chado. should make a generic subroutine that can be checked at the end of the proforma - currently this check against chado is only done in gene.pl in amongst all the complex cross-checks
-
-
 
 ### Updated:
 
-gm171114.
+gm240619.

--- a/doc/specs/gene/G2c.txt
+++ b/doc/specs/gene/G2c.txt
@@ -30,12 +30,8 @@ Cross-checks with other fields
 
   * checks done after parsing entire proforma
 
-    * If G2c is filled in:
 
-       * print an error if the symbol given in G1e (if filled in) or G1a (if G1e not filled in) does not have a valid fullname in chado
-
-       * if the symbol given in G1e (if filled in) or G1a (if G1e not filled in) does have a valid fullname in chado, print an error if the value in G2c does not match that valid chado fullname
-
+    * sub cross_check_full_name_rename checks that the value in G2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
 
     * If G2c is filled in, G2a must be filled in (compare_field_pairs, pair_test = 'dependent')
 
@@ -72,4 +68,4 @@ Cross-checks with other fields
 
 ### Updated:
 
-gm170131.
+gm240619.

--- a/doc/specs/genegroup/GG2c.txt
+++ b/doc/specs/genegroup/GG2c.txt
@@ -36,6 +36,9 @@ Cross-checks with other fields:
 
 * If GG2c is filled in, GG2a must be filled in (compare_field_pairs, pair_test = 'dependent')
 
+* sub cross_check_full_name_rename checks that the value in GG2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
+
+* GG2c and GG1f must not both be filled in (compare_field_pairs, pair_test = 'single')
 
 ### Related fields:
 
@@ -49,7 +52,6 @@ Cross-checks with other fields:
 
 Not implemented any of the following:
 
-* check that the value given in GG2c is really a valid fullname in chado.
 
 Cross-checks with other fields:
 
@@ -76,4 +78,4 @@ This is only allowed if you are trying to rename a gene's symbol without changin
 
 ### Updated:
 
-gm151001.
+gm240619.

--- a/doc/specs/strain/SN2c.txt
+++ b/doc/specs/strain/SN2c.txt
@@ -40,6 +40,7 @@ Cross-checks between fields:
 
 * If SN2c and SN2a are both filled in, they must not be the same value  (compare_field_pairs, identity_test = 'not same')
 
+* sub cross_check_full_name_rename checks that the value in SN2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
 
 ### Related fields:
 
@@ -51,12 +52,8 @@ Cross-checks between fields:
 
 ### Status:
 
-Not yet implemented:
-
-* there is no check that the value given in TO2c is really a valid fullname in chado. should make a generic subroutine that can be checked at the end of the proforma - currently this check against chado is only done in gene.pl in amongst all the complex cross-checks
-
 
 
 ### Updated:
 
-gm231115.
+gm240619.

--- a/doc/specs/variant/AB2c.txt
+++ b/doc/specs/variant/AB2c.txt
@@ -26,6 +26,10 @@ No (Implemented)
 
 ### Checks:
 
+Cross-checks between fields:
+
+* sub cross_check_full_name_rename checks that the value in AB2c matches the fullname in chado of the subject of the proforma ie. the symbol in the symbol rename field (if both the symbol and fullname are being renamed) or the symbol in the primary symbol field (if only the fullname is being renamed).
+
 
 ### Related fields:
 
@@ -41,10 +45,8 @@ doc: checked that doc reflects what has been implemented
 
 Not yet implemented:
 
-* similar to G2c, there is no check that the value given in AB2c is really a valid fullname in chado.
-
 * there is no cross-check of AB2a with AB2c - need to add something that takes into account whether or not the allele is new (AB1g) and whether or not rename/merge fields (AB1e/AB1f) are filled in. [gm131211]
 
 ### Updated:
 
-gm151001.
+gm240619.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.75"; #  fixing bug in G35 checking (removing overly stringent false-positive message) (related to DC-417).
+our $Peeves_version = "2.76"; #  new subroutine to cross-check that full name in rename field is what is in chado for that object (DC-1076).
 
 =head2 Version
 

--- a/production/aberration.pl
+++ b/production/aberration.pl
@@ -504,6 +504,9 @@ FIELD:
 
 	plingc_merge_check ($file, $change_count,'A1f', \@A1f_list, $proforma_fields{'A1f'});
 
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'A', $g_num_syms, $primary_symbol_list, \@A1e_list, \@A2c_list, \%proforma_fields);
+
 check_filled_in_for_new_feature ($file, 'A9', $g_num_syms, \@A9_list, \@A1g_list, \@A1e_list, \@A1f_list, \%proforma_fields, 'yes');
 check_filled_in_for_new_feature ($file, 'A26', $g_num_syms, \@A26_list, \@A1g_list, \@A1e_list, \@A1f_list, \%proforma_fields, 'yes');
 

--- a/production/allele.pl
+++ b/production/allele.pl
@@ -630,6 +630,9 @@ FIELD:
 
 	plingc_merge_check ($file, $change_count,'GA1f', \@GA1f_list, $proforma_fields{'GA1f'});
 
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'GA', $hash_entries, $primary_symbol_list, \@GA1e_list, \@GA2c_list, \%proforma_fields);
+
 # If GA2c is filled in, GA2a must be filled in. PLUS value in GA2a and GA2c must not be the same
 compare_field_pairs ($file, $hash_entries, 'GA2c', \@GA2c_list, 'GA2a', \@GA2a_list, \%proforma_fields, 'dependent', 'not same');
 

--- a/production/balancer.pl
+++ b/production/balancer.pl
@@ -279,6 +279,10 @@ FIELD:
 
 	plingc_merge_check ($file, $change_count,'AB1f', \@AB1f_list, $proforma_fields{'AB1f'});
 
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'AB', $hash_entries, $primary_symbol_list, \@AB1e_list, \@AB2c_list, \%proforma_fields);
+
+
 # check that valid symbol is in the symbol synonym field when !c-ing it under the  'unattributed' pub.
 # Only do the check if the symbol synonym field contains some data
 if ($unattributed && $#AB1b_list + 1 == $hash_entries) {

--- a/production/chado.pl
+++ b/production/chado.pl
@@ -257,6 +257,17 @@ sub set_up_chado_queries ()
     								AND g.is_obsolete = \'f\'
     								AND s.synonym_sgml=?;');
 
+    $prepared_queries{'grp_fullname_from_id'} = $chado->prepare ('SELECT DISTINCT s.synonym_sgml
+								FROM grp g, grp_synonym gs, synonym s, cvterm cvt
+								WHERE g.grp_id = gs.grp_id
+								AND gs.synonym_id = s.synonym_id
+								AND gs.is_current = \'t\'
+								AND gs.is_internal = \'f\'
+								AND s.type_id = cvt.cvterm_id
+								AND cvt.name = \'fullname\'
+								AND g.is_obsolete = \'f\'
+								AND g.uniquename=?;');
+
 
 # humanhealth
     $prepared_queries{'humanhealth_symbol_from_id'} = $chado->prepare ('SELECT DISTINCT s.synonym_sgml, h.is_obsolete
@@ -324,6 +335,17 @@ sub set_up_chado_queries ()
     								   AND st.is_obsolete = \'f\'
     								   AND s.synonym_sgml=?;');
 
+# strain
+    $prepared_queries{'strain_fullname_from_id'} = $chado->prepare ('SELECT DISTINCT s.synonym_sgml
+    								   FROM strain st, strain_synonym sts, synonym s, cvterm cvt
+    								   WHERE st.strain_id = sts.strain_id
+    								   AND sts.synonym_id = s.synonym_id
+    								   AND sts.is_current = \'t\'
+    								   AND sts.is_internal = \'f\'
+    								   AND s.type_id = cvt.cvterm_id
+    								   AND cvt.name = \'fullname\'
+    								   AND st.is_obsolete = \'f\'
+    								   AND st.uniquename=?;');
 
 # interaction
 

--- a/production/experimental_tool.pl
+++ b/production/experimental_tool.pl
@@ -255,10 +255,12 @@ FIELD:
 
     check_presence ($file, \%proforma_fields, \@inclusion_essential, $primary_symbol_list);
 
-	plingc_merge_check ($file, $change_count,'TO1g', \@TO1g_list, $proforma_fields{'TO1g'});
+    plingc_merge_check ($file, $change_count,'TO1g', \@TO1g_list, $proforma_fields{'TO1g'});
 	
     rename_merge_check ($file, 'TO1c', \@TO1c_list, $proforma_fields{'TO1c'}, 'TO1g', \@TO1g_list, $proforma_fields{'TO1g'});
 	
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'TO', $hash_entries, $primary_symbol_list, \@TO1c_list, \@TO2c_list, \%proforma_fields);
 
 	cross_check_harv_style_symbol_rename_merge_fields ($file, 'TO', $hash_entries, \@primary_id_list, $primary_symbol_list, \@TO1c_list, \@TO1g_list, \%proforma_fields);
 

--- a/production/gene.pl
+++ b/production/gene.pl
@@ -512,54 +512,6 @@ FIELD:
 compare_field_pairs ($file, $g_num_syms, 'G2c', \@G2c_list, 'G2a', \@G2a_list, \%proforma_fields, 'dependent::(unless you are trying to delete the fullname in chado)', 'not same');
 
 
-# test of validity of fullname info in G2c - do at end of proforma as require G1a/G1e info
-    if ($g_num_syms and $#G2c_list + 1 == $g_num_syms) { # Some data in G1a and G2c.
-
-	   	for (my $i = 0; $i < $g_num_syms; $i++) {
-
-			if (defined $G2c_list[$i] && $G2c_list[$i] ne '') {
-
-				my $id;
-				my $relevant_field;
-
-				if ($G1e_list[$i] && $G1e_list[$i] ne '') {
-
-					$id = valid_chado_symbol($G1e_list[$i], 'FBgn');
-					$relevant_field = 'G1e';
-				} else {
-
-					$id = valid_chado_symbol($g_gene_sym_list->[$i], 'FBgn');
-					$relevant_field = 'G1a';
-
-
-				}
-
-				if ($id) {
-
-					my $chado_fullname_ref = chat_to_chado ('feature_fullname_from_id', $id)->[0];
-
-					if (defined $chado_fullname_ref) {
-						unless ($G2c_list[$i] eq utf2sgml(join (' ', @{$chado_fullname_ref}))) {
-
-							report ($file, "%s: Fullname given '%s' does not match the fullname in chado ('%s') of the symbol '%s' given in %s.", 'G2c', $G2c_list[$i], (utf2sgml(join (' ', @{$chado_fullname_ref}))), ($relevant_field eq 'G1e' ? $G1e_list[$i] : $g_gene_sym_list->[$i]), $relevant_field);
-
-						}
-
-					} else {
-
-						report ($file, "%s: You have given a full name in this field, but the symbol '%s' in %s does not have a fullname in chado", 'G2c', ($relevant_field eq 'G1e' ? $G1e_list[$i] : $g_gene_sym_list->[$i]), $relevant_field);
-
-					}
-
-				}
-
-
-			}
-		}
-	}
-
-
-
 
 ## cross-checks based on 'status' of gene in proforma
 	if ($g_num_syms) {
@@ -709,6 +661,10 @@ compare_field_pairs ($file, $g_num_syms, 'G2c', \@G2c_list, 'G2a', \@G2a_list, \
 # no !c if G1f is filled in
 
 	plingc_merge_check ($file, $change_count,'G1f', \@G1f_list, $proforma_fields{'G1f'});
+
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'G', $g_num_syms, $g_gene_sym_list, \@G1e_list, \@G2c_list, \%proforma_fields);
+
 
 # G28b checking.  G28b is not required to contain data but if it does it must be cross-checked with G1e and
 # G1f.

--- a/production/genegroup.pl
+++ b/production/genegroup.pl
@@ -332,6 +332,9 @@ FIELD:
 # no !c if GG1f is filled in
 	plingc_merge_check ($file, $change_count,'GG1f', \@GG1f_list, $proforma_fields{'GG1f'});
 
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'GG', $hash_entries, $primary_symbol_list, \@GG1e_list, \@GG2c_list, \%proforma_fields);
+
 
 # If GG2c is filled in, GG2a must be filled in. PLUS value in GG2a and GG2c must not be the same
 compare_field_pairs ($file, $hash_entries, 'GG2c', \@GG2c_list, 'GG2a', \@GG2a_list, \%proforma_fields, 'dependent', 'not same');

--- a/production/strain.pl
+++ b/production/strain.pl
@@ -299,6 +299,9 @@ FIELD:
 # no !c in other fields if merge field is filled in
 	plingc_merge_check ($file, $change_count,'SN1e', \@SN1e_list, $proforma_fields{'SN1e'});
 
+# cross-checks for fullname renames
+	cross_check_full_name_rename ($file, 'SN', $hash_entries, $primary_symbol_list, \@SN1d_list, \@SN2c_list, \%proforma_fields);
+
 # rename and merge fields must not both contain data.
 
 	rename_merge_check ($file, 'SN1d', \@SN1d_list, $proforma_fields{'SN1d'}, 'SN1e', \@SN1e_list, $proforma_fields{'SN1e'});

--- a/records2test/DC-1076/gm1.edit
+++ b/records2test/DC-1076/gm1.edit
@@ -1,0 +1,121 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Hsap\DRD2
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1e.  Action - rename this gene symbol                       :
+! G1f.  Action - merge these genes (symbols)                   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :
+! G2a.  Action - gene name to use in FlyBase                *e :new name for DRD2
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :dopamine receptor D2
+! G27.  Etymology                                           *u :
+! G28b. Source for merge/identity of                      [SoftCV] *q :
+! G28a. Relationship to other genes - comments         [free text] *q :
+! G41.  Gene nomenclature - comments                   [free text] *q :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G14a. Miscellaneous comments                              *u :
+! G15.  Internal notes  *W :??no error
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :dpp
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1e.  Action - rename this gene symbol                       :
+! G1f.  Action - merge these genes (symbols)                   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :
+! G2a.  Action - gene name to use in FlyBase                *e :another new name
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :hedgehog
+! G27.  Etymology                                           *u :
+! G28b. Source for merge/identity of                      [SoftCV] *q :
+! G28a. Relationship to other genes - comments         [free text] *q :
+! G41.  Gene nomenclature - comments                   [free text] *q :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G14a. Miscellaneous comments                              *u :
+! G15.  Internal notes  *W :??error - full name is not the name in chado for dpp
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :new_symbol
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1e.  Action - rename this gene symbol                       :en
+! G1f.  Action - merge these genes (symbols)                   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :n
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :
+! G2a.  Action - gene name to use in FlyBase                *e :new name for engrailed
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :engrailed
+! G27.  Etymology                                           *u :
+! G28b. Source for merge/identity of                      [SoftCV] *q :
+! G28a. Relationship to other genes - comments         [free text] *q :
+! G41.  Gene nomenclature - comments                   [free text] *q :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G14a. Miscellaneous comments                              *u :
+! G15.  Internal notes  *W :??no error
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :another_symbol
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1e.  Action - rename this gene symbol                       :Dpp10
+! G1f.  Action - merge these genes (symbols)                   :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :n
+! G30.  Class of gene, if new (SO_term ; ID)           [CV] *t :
+! G2a.  Action - gene name to use in FlyBase                *e :
+! G2b.  Gene name(s) used in reference                      *V :
+! G2c.  Action - rename this gene name                         :not the right name
+! G27.  Etymology                                           *u :
+! G28b. Source for merge/identity of                      [SoftCV] *q :
+! G28a. Relationship to other genes - comments         [free text] *q :
+! G41.  Gene nomenclature - comments                   [free text] *q :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G14a. Miscellaneous comments                              *u :
+! G15.  Internal notes  *W :??error = G2c is not valid name of symbol in G1e
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1076/gm2.edit
+++ b/records2test/DC-1076/gm2.edit
@@ -1,0 +1,69 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENEGROUP PROFORMA     Version 8: 12 Jul 2021
+!
+! GG1a. Gene group symbol                               *a :MRP
+! GG1b. Gene group symbol synonym(s)                    *i :
+! GG1e. Action - rename this gene group symbol      :
+! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :y
+! GG2a. Action - gene group name to use in FlyBase      *e :no error
+! GG2b. Gene group name synonym(s)                      *V :
+! GG2c. Action - rename this gene group name        :MITOCHONDRIAL RIBOSOMAL COMPONENTS
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEGROUP PROFORMA     Version 8: 12 Jul 2021
+!
+! GG1a. Gene group symbol                               *a :MRPL
+! GG1b. Gene group symbol synonym(s)                    *i :
+! GG1e. Action - rename this gene group symbol      :
+! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :y
+! GG2a. Action - gene group name to use in FlyBase      *e :new group name
+! GG2b. Gene group name synonym(s)                      *V :
+! GG2c. Action - rename this gene group name        :MITOCHONDRIAL LARGE RIBOSOMAL COMPONENTS error
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEGROUP PROFORMA     Version 8: 12 Jul 2021
+!
+! GG1a. Gene group symbol                               *a :enewgroup
+! GG1b. Gene group symbol synonym(s)                    *i :
+! GG1e. Action - rename this gene group symbol      :MRPS
+! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :n
+! GG2a. Action - gene group name to use in FlyBase      *e :no error in name
+! GG2b. Gene group name synonym(s)                      *V :
+! GG2c. Action - rename this gene group name        :MITOCHONDRIAL SMALL RIBOSOMAL COMPONENTS
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENEGROUP PROFORMA     Version 8: 12 Jul 2021
+!
+! GG1a. Gene group symbol                               *a :RPldjroje
+! GG1b. Gene group symbol synonym(s)                    *i :
+! GG1e. Action - rename this gene group symbol      :RP
+! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :n
+! GG2a. Action - gene group name to use in FlyBase      *e :is error in name in GG2c
+! GG2b. Gene group name synonym(s)                      *V :
+! GG2c. Action - rename this gene group name        :not the right name for RP group
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1076/gm3.edit
+++ b/records2test/DC-1076/gm3.edit
@@ -1,0 +1,180 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! EXPERIMENTAL TOOL PROFORMA                       Version 4:  31 Oct 2017
+!
+! TO1f. Database ID for experimental tool (FBto)       :FBto0000010
+! TO1a. Experimental tool symbol to use in database    :Citrine
+! TO1b.  Experimental tool symbol synonym(s)           :
+! TO10. Species of tool (organism.abbreviation)        :
+!
+! TO1c. Action - rename this experimental tool symbol  :
+! TO1g. Action - merge these experimental tools (FBto) :
+! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+! TO1i. Action - dissociate TO1a from reference (y/blank) :
+!
+! TO2a.  Action - experimental tool name to use in FlyBase       :no error
+! TO2b.  Experimental tool name synonym(s)                       :
+! TO2c.  Action - rename this experimental tool name             :Citrine fluorescent protein
+!
+! TO4.   Experimental tool uses [CV]                             :
+! TO5.   Description of experimental tool [free text]            :
+!
+! TO6a. Accession number for tool (dupl section for multiple)    :
+! TO6b. FlyBase database symbol (DB1a) for accession in TO6a     :
+! TO6c. Title for TO6a (if desired) [free text]                  :
+! TO6d. Action - dissociate accession in TO6a/TO6b from tool in TO1a? (blank/y) :
+!
+! TO7a. Compatible tools(s) (symbol) :
+! TO7b. Other related tools(s) (symbol) :
+! TO7c. Gene of origin (symbol)   :
+!
+! TO8.  Comments [free text] :
+! TO9.  Internal notes       :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! EXPERIMENTAL TOOL PROFORMA                       Version 4:  31 Oct 2017
+!
+! TO1f. Database ID for experimental tool (FBto)       :FBto0000012
+! TO1a. Experimental tool symbol to use in database    :CLIPm-tag
+! TO1b.  Experimental tool symbol synonym(s)           :
+! TO10. Species of tool (organism.abbreviation)        :
+!
+! TO1c. Action - rename this experimental tool symbol  :
+! TO1g. Action - merge these experimental tools (FBto) :
+! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+! TO1i. Action - dissociate TO1a from reference (y/blank) :
+!
+! TO2a.  Action - experimental tool name to use in FlyBase       :
+! TO2b.  Experimental tool name synonym(s)                       :
+! TO2c.  Action - rename this experimental tool name             :no name in chado
+!
+! TO4.   Experimental tool uses [CV]                             :
+! TO5.   Description of experimental tool [free text]            :
+!
+! TO6a. Accession number for tool (dupl section for multiple)    :
+! TO6b. FlyBase database symbol (DB1a) for accession in TO6a     :
+! TO6c. Title for TO6a (if desired) [free text]                  :
+! TO6d. Action - dissociate accession in TO6a/TO6b from tool in TO1a? (blank/y) :
+!
+! TO7a. Compatible tools(s) (symbol) :
+! TO7b. Other related tools(s) (symbol) :
+! TO7c. Gene of origin (symbol)   :
+!
+! TO8.  Comments [free text] :
+! TO9.  Internal notes       :??error - this tool has no name in chado
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! EXPERIMENTAL TOOL PROFORMA                       Version 4:  31 Oct 2017
+!
+! TO1f. Database ID for experimental tool (FBto)       :FBto0000013
+! TO1a. Experimental tool symbol to use in database    :CyPet
+! TO1b.  Experimental tool symbol synonym(s)           :
+! TO10. Species of tool (organism.abbreviation)        :
+!
+! TO1c. Action - rename this experimental tool symbol  :
+! TO1g. Action - merge these experimental tools (FBto) :
+! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+! TO1i. Action - dissociate TO1a from reference (y/blank) :
+!
+! TO2a.  Action - experimental tool name to use in FlyBase       :new tool name
+! TO2b.  Experimental tool name synonym(s)                       :
+! TO2c.  Action - rename this experimental tool name             :error - this is not the name in chado
+!
+! TO4.   Experimental tool uses [CV]                             :
+! TO5.   Description of experimental tool [free text]            :
+!
+! TO6a. Accession number for tool (dupl section for multiple)    :
+! TO6b. FlyBase database symbol (DB1a) for accession in TO6a     :
+! TO6c. Title for TO6a (if desired) [free text]                  :
+! TO6d. Action - dissociate accession in TO6a/TO6b from tool in TO1a? (blank/y) :
+!
+! TO7a. Compatible tools(s) (symbol) :
+! TO7b. Other related tools(s) (symbol) :
+! TO7c. Gene of origin (symbol)   :
+!
+! TO8.  Comments [free text] :
+! TO9.  Internal notes       :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! EXPERIMENTAL TOOL PROFORMA                       Version 4:  31 Oct 2017
+!
+! TO1f. Database ID for experimental tool (FBto)       :FBto0000780
+! TO1a. Experimental tool symbol to use in database    :newDBE
+! TO1b.  Experimental tool symbol synonym(s)           :
+! TO10. Species of tool (organism.abbreviation)        :
+!
+! TO1c. Action - rename this experimental tool symbol  :DBE2
+! TO1g. Action - merge these experimental tools (FBto) :
+! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+! TO1i. Action - dissociate TO1a from reference (y/blank) :
+!
+! TO2a.  Action - experimental tool name to use in FlyBase       :no error in this rename
+! TO2b.  Experimental tool name synonym(s)                       :
+! TO2c.  Action - rename this experimental tool name             :Drosophila-optimized base editor 2
+!
+! TO4.   Experimental tool uses [CV]                             :
+! TO5.   Description of experimental tool [free text]            :
+!
+! TO6a. Accession number for tool (dupl section for multiple)    :
+! TO6b. FlyBase database symbol (DB1a) for accession in TO6a     :
+! TO6c. Title for TO6a (if desired) [free text]                  :
+! TO6d. Action - dissociate accession in TO6a/TO6b from tool in TO1a? (blank/y) :
+!
+! TO7a. Compatible tools(s) (symbol) :
+! TO7b. Other related tools(s) (symbol) :
+! TO7c. Gene of origin (symbol)   :
+!
+! TO8.  Comments [free text] :
+! TO9.  Internal notes       :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! EXPERIMENTAL TOOL PROFORMA                       Version 4:  31 Oct 2017
+!
+! TO1f. Database ID for experimental tool (FBto)       :FBto0000532
+! TO1a. Experimental tool symbol to use in database    :dCas9::GSnew
+! TO1b.  Experimental tool symbol synonym(s)           :
+! TO10. Species of tool (organism.abbreviation)        :Ssss
+!
+! TO1c. Action - rename this experimental tool symbol  :dCas9::GS
+! TO1g. Action - merge these experimental tools (FBto) :
+! TO1h. Action - obsolete TO1a in FlyBase (y/blank)       :
+! TO1i. Action - dissociate TO1a from reference (y/blank) :
+!
+! TO2a.  Action - experimental tool name to use in FlyBase       :double rename with error
+! TO2b.  Experimental tool name synonym(s)                       :
+! TO2c.  Action - rename this experimental tool name             :dCas9::GeneSwitch driversdsudasus
+!
+! TO4.   Experimental tool uses [CV]                             :
+! TO5.   Description of experimental tool [free text]            :
+!
+! TO6a. Accession number for tool (dupl section for multiple)    :
+! TO6b. FlyBase database symbol (DB1a) for accession in TO6a     :
+! TO6c. Title for TO6a (if desired) [free text]                  :
+! TO6d. Action - dissociate accession in TO6a/TO6b from tool in TO1a? (blank/y) :
+!
+! TO7a. Compatible tools(s) (symbol) :
+! TO7b. Other related tools(s) (symbol) :
+! TO7c. Gene of origin (symbol)   :
+!
+! TO8.  Comments [free text] :
+! TO9.  Internal notes       :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/DC-1076/gm4.edit
+++ b/records2test/DC-1076/gm4.edit
@@ -1,0 +1,93 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0105495
+! P2.   Parent multipub abbreviation               *w :
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :FBsn0000006
+! SN1a.  Strain symbol to use in FlyBase                :DGRP-21
+! SN1c.  Strain symbol(s) used in reference             :
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :Dmel
+! SN1g.  Strain type (free text; use "wild type")   :
+!
+! SN2a.  Action - strain name to use in FlyBase     :no error
+! SN2b.  Strain name(s) used in reference           :
+! SN2c.  Action - replace this strain name          :Drosophila Genetic Reference Panel 21
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :
+! SN1e.  Action - merge these strains (symbol)                       :
+! SN13.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next strain proforma below.
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :FBsn0000001
+! SN1a.  Strain symbol to use in FlyBase                :Oregon-R-modENCODE
+! SN1c.  Strain symbol(s) used in reference             :
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :Dmel
+! SN1g.  Strain type (free text; use "wild type")   :
+!
+! SN2a.  Action - strain name to use in FlyBase     :new name
+! SN2b.  Strain name(s) used in reference           :
+! SN2c.  Action - replace this strain name          :errror - this is not the name
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :
+! SN1e.  Action - merge these strains (symbol)                       :
+! SN13.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next strain proforma below.
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :new
+! SN1a.  Strain symbol to use in FlyBase                :
+! SN1c.  Strain symbol(s) used in reference             :
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :Dmel
+! SN1g.  Strain type (free text; use "wild type")   :
+!
+! SN2a.  Action - strain name to use in FlyBase     :
+! SN2b.  Strain name(s) used in reference           :
+! SN2c.  Action - replace this strain name          :
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :
+! SN1e.  Action - merge these strains (symbol)                       :
+! SN13.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next strain proforma below.
+! STRAIN PROFORMA               Version 19: 2 May 2013
+!
+! SN1b.  FlyBase strain ID (FBsn, required if not new)  :new
+! SN1a.  Strain symbol to use in FlyBase                :
+! SN1c.  Strain symbol(s) used in reference             :
+! SN1f.  Species of strain (predominant if hybrid) [symbol] :Dmel
+! SN1g.  Strain type (free text; use "wild type")   :
+!
+! SN2a.  Action - strain name to use in FlyBase     :
+! SN2b.  Strain name(s) used in reference           :
+! SN2c.  Action - replace this strain name          :
+!
+! SN1d.  Action - rename this strain symbol (existing symbol)        :
+! SN1e.  Action - merge these strains (symbol)                       :
+! SN13.  Internal notes   :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next strain proforma below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
…is what is in chado for that object (DC-1076)

- new subroutine `cross_check_full_name_rename` is in `tools.pl` (it was made based on existing code in `gene.pl` which has been deleted from that file)
- a call to the new sub is added to `aberration.pl`, `allele.pl`, `balancer.pl`, `gene.pl`, `genegroup.pl`, `experimental_tool.pl`, `strain.pl`
- a couple of chado queries to get full names from grp and strain tables added to `chado.pl`
- new test records in `records2test/DC-1076`