### PR TITLE
Add warning if (with ) allele is transgenic (FTA-76)

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -1025,3 +1025,5 @@ our $Peeves_version = "2.78"; #  Adding new curator info.
 our $Peeves_version = "2.79.1"; #  Add Peeves checks for new GG14 field (DC-1084): basic checks
 our $Peeves_version = "2.79.2"; #  Add Peeves checks for new GG14 field (DC-1084): within field checks
 our $Peeves_version = "2.79.3"; #  Add Peeves checks for new GG14 field (DC-1084): between field checks
+# 1.7.2025
+our $Peeves_version = "2.80"; #  Add warning if (with ) allele is transgenic (FTA-76)

--- a/doc/specs/allele/GA4.txt
+++ b/doc/specs/allele/GA4.txt
@@ -32,8 +32,7 @@ checks within field (in validate_cvterm_field):
    * warns if there is a blank line within the data
    * warns if there are any duplicated values
 
-* each value must match a value from the descendents of the 'allele morphy class' node of
-flybase_controlled_vocabulary.obo (and the term must not have is_obsolete = true).
+* each value must be a valid FBcv term from the 'allele_class' namespace.
 
 ### Related fields:
 
@@ -44,11 +43,10 @@ flybase_controlled_vocabulary.obo (and the term must not have is_obsolete = true
 
 ### Status:
 
-doc: doc reflects what has been implemented
 
 
 
 
 ### Updated:
 
-gm151001.
+gm241213.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.79.3"; #  Add Peeves checks for new GG14 field (DC-1084): between field checks
+our $Peeves_version = "2.80"; #  Add warning if (with ) allele is transgenic (FTA-76)
 
 =head2 Version
 

--- a/production/allele.pl
+++ b/production/allele.pl
@@ -1052,7 +1052,7 @@ sub do_withs ($$$$)
 
     if ($with =~ m/, /) {
 
-	report ($file, "%s: '(with )' portion contains a comma. Please follow 'coping with complex with' instructions in the phen_curation.sop to rearrange the following line to prevent a problematic genotype:\n$context", $code);
+	report ($file, "%s: '(with )' portion contains a comma. Please follow 'coping with complex with' instructions in the phen_curation.sop to rearrange the following line to prevent a problematic genotype:\n%s", $code, $context);
 
     }
 
@@ -1063,7 +1063,7 @@ sub do_withs ($$$$)
 # $with_thing has to be either any valid aberration symbol or a rather constrained allele symbol.
 
 	next if valid_symbol ($with_thing, 'FBab');		# Always ok if a valid abs symbol
-	if (valid_symbol ($with_thing, 'FBal'))
+	if (my $fbal = valid_symbol ($with_thing, 'FBal'))
 	{
 	    if (my ($gene, undef) = ($with_thing =~ /(.+)\[(.+)\]$/))	# Slice out gene portion.
 	    {
@@ -1071,6 +1071,15 @@ sub do_withs ($$$$)
 					      "%s: Mismatch between gene symbol '%s' in GA1a " .
 					      "and the gene portion '%s' given in '(with %s)' in the line\n%s",
 					      $code, $g1a_gene, $gene, $with, $context);
+	    }
+
+	    # add check to see whether allele is transgenic and print a warning if so, to prevent problematic genotypes being made in db
+	    my $assoc_list = chat_to_chado ('associated_with_FBtp', $fbal);
+	    if (@{$assoc_list}) {
+
+		report ($file, "%s: '(with )' portion contains a transgenic allele (%s) which will cause a problematic genotype on loading. Please rearrange the line (replacing %s with the allele in GA1a) and put it in the %s proforma instead:\n%s", $code, $with_thing, $with_thing, $with_thing, $context);
+
+
 	    }
 
 	}

--- a/production/chado.pl
+++ b/production/chado.pl
@@ -356,6 +356,7 @@ sub set_up_chado_queries ()
 
 # Allele specific block
 
+# this query gets associated_with FBal when an FBtp/FBti id is given as the argument for the query
     $prepared_queries{'associated_with_FBal'} = $chado->prepare ('SELECT f2.uniquename
 								  FROM feature f1, feature f2,
 								       feature_relationship fr, cvterm cv
@@ -364,6 +365,18 @@ sub set_up_chado_queries ()
 								  AND f2.feature_id = fr.subject_id
 								  AND cv.cvterm_id=fr.type_id
 								  AND cv.name=\'associated_with\';');
+
+# this query gets associated_with FBtps for an FBal id is given as the argument for the query
+    $prepared_queries{'associated_with_FBtp'} = $chado->prepare ('SELECT f2.uniquename
+								  FROM feature f1, feature f2,
+								       feature_relationship fr, cvterm cv
+								  WHERE f1.uniquename=?
+								  AND f1.feature_id = fr.subject_id
+								  AND f2.feature_id = fr.object_id
+								  AND f2.uniquename like \'FBtp%\'
+								  AND cv.cvterm_id=fr.type_id
+								  AND cv.name=\'associated_with\';');
+
 
 # Organism information
 

--- a/records2test/FTA-76/ao1.phen
+++ b/records2test/FTA-76/ao1.phen
@@ -1,0 +1,113 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0262206
+! P2.   Parent multipub abbreviation               *w :Cell Rep.
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Pdzd8
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Pdzd8[KO]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA56.  Phenotype (class | qualifier(s)) [CV]            *k :(with Pdzd8[SMP.UAS.Tag:V5]) abnormal neuroanatomy | larval stage | conditional
+! GA17.  Phenotype (anatomy | qualifier(s)) [CV]          *k :(with Pdzd8[SMP.UAS.Tag:V5]) NMJ bouton | larval stage | conditional
+! GA28a. Genetic interaction (class, effect) [CV]           *S :(with Pdzd8[SMP.UAS.Tag:V5]) abnormal neuroanatomy | larval stage, UI { Atg1[00305]/+ }
+! GA28b. Genetic interaction (anatomy, effect) [CV]         *S :(with Pdzd8[SMP.UAS.Tag:V5]) NMJ bouton | larval stage | decreased number, UI { Atg1[00305]/+ }
+NMJ bouton | larval stage | decreased number, UI { Syx17[f03584]/+ }
+(with Pdzd8[SMP.UAS.Tag:V5]) presynaptic active zone | larval stage | decreased number, suppresible { Atg1[00305]/+ }
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Atg1
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Atg1[00305]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA56.  Phenotype (class | qualifier(s)) [CV]            *k :(with Atg1[00305]) abnormal neuroanatomy | larval stage
+! GA17.  Phenotype (anatomy | qualifier(s)) [CV]          *k :(with Atg1[00305]) presynaptic active zone | larval stage | decreased number
+(with Atg1[00305], Atg1[CB-6698-3]) NMJ bouton | larval stage | decreased number
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Atg1[UAS.cSa]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA56.  Phenotype (class | qualifier(s)) [CV]            *k :(with Atg1[3]) abnormal neuroanatomy | larval stage { Scer\GAL4[elav-C155] }
+! GA17.  Phenotype (anatomy | qualifier(s)) [CV]          *k :(with Atg1[3]) NMJ bouton | larval stage | increased number { Scer\GAL4[elav-C155] }
+! GA28a. Genetic interaction (class, effect) [CV]           *S :(with Atg1[3]) abnormal neuroanatomy | larval stage { Scer\GAL4[elav-C155] }, suppressible { Pdzd8[KO]/+ }
+! GA28b. Genetic interaction (anatomy, effect) [CV]         *S :(with Atg1[3]) NMJ bouton | larval stage | increased number { Scer\GAL4[elav-C155] }, suppressible { Pdzd8[KO]/+ }
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Hsap\PDZD8
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Hsap\PDZD8[UAS.GFP]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA56.  Phenotype (class | qualifier(s)) [CV]            *k :abnormal neuroanatomy | larval stage { Scer\GAL4[elav-C155] }
+! GA17.  Phenotype (anatomy | qualifier(s)) [CV]          *k :NMJ bouton | larval stage | increased number { Scer\GAL4[elav-C155] }
+! GA10a. Associated construct                                *I :
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA14.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
This change is to prevent a particular class of problematic genotype in the db (warning means curator can adjust record and submit same data under the 'other' allele, resulting in a valid genotype)

(doc changes in doc/GA4.txt are not related to this change, they are just updating the doc for something I noticed was out-of-date)