### PR TITLE
Replace obsoleted 'process group' term in GG4 test records

### DIFF
--- a/records2test/GG4/gm1
+++ b/records2test/GG4/gm1
@@ -63,7 +63,7 @@
 ! GG2c. Action - rename this gene group name        :
 !
 ! GG4.  Type of gene group [CV]  *t :loss of function allele
-process group
+pathway group
 !
 ! GG12. Internal notes  *W :??error - multiple values
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -94,7 +94,7 @@ rewureow
 ! GG2b. Gene group name(s) used in reference            *V :
 ! GG2c. Action - rename this gene group name        :
 !
-! GG4.  Type of gene group [CV]  *t :process group
+! GG4.  Type of gene group [CV]  *t :pathway group
 !
 ! GG12. Internal notes  *W :??error -filled in for rename
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/records2test/GG4/pg1.edit
+++ b/records2test/GG4/pg1.edit
@@ -8,7 +8,7 @@
 ! GG1a. Gene group symbol                               *a :G-TUC
 ! GG1b. Gene group symbol synonym(s)                    *i :
 ! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :y
-!c GG4.  Type of gene group [CV]  *t :process group
+!c GG4.  Type of gene group [CV]  *t :pathway group
 ! GG12. Internal notes  *W :??should pass: existing group, !c has value
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/GG4/pg5.edit
+++ b/records2test/GG4/pg5.edit
@@ -8,7 +8,7 @@
 ! GG1a. Gene group symbol                               *a :DRS
 ! GG1b. Gene group symbol synonym(s)                    *i :
 ! GG1g. Is GG1a the current symbol of a gene group? (y/n)  :y
-! GG4.  Type of gene group [CV]  *t :process group
+! GG4.  Type of gene group [CV]  *t :pathway group
 ! GG12. Internal notes  *W :??should fail: existing group, cannot add, only !c
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/records2test/GG4/pg6.edit
+++ b/records2test/GG4/pg6.edit
@@ -39,7 +39,7 @@
 ! GG2b. Gene group name synonym(s)                      *V :
 ! GG2c. Action - rename this gene group name        :
 !
-! GG4.  Type of gene group [CV]  *t :process group
+! GG4.  Type of gene group [CV]  *t :pathway group
 ! GG12. Internal notes  *W :??should fail - GG4 filled in, forgot to plingc
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! GENEGROUP PROFORMA     Version 8: 12 Jul 2021


### PR DESCRIPTION
## Summary

- Replace all occurrences of `process group` (FBcv:0003018) with `pathway group` (FBcv:0003017) in GG4 test proforma records
- 4 files changed in `records2test/GG4/`: `gm1`, `pg1.edit`, `pg5.edit`, `pg6.edit`

## Context

**This PR is contingent on Steven Marygold's proposed FBcv changes being finalized.** Do not merge until the ontology changes are in place.

Steven is proposing to obsolete `process group` (FBcv:0003018) as part of a gene group type cleanup ahead of Alliance submission. A grep across all FlyBase GitHub repos confirmed that the only code-level references to this term are in these test proforma records. No production code depends on it.

The replacement term `pathway group` (FBcv:0003017) is a valid `group_descriptor` term that will remain in the restructured FBcv tree.

## Test semantics

No test behavior changes -- each test case exercises proforma parsing logic (plingc handling, multi-value errors, new-vs-existing group validation), not the specific CV term value.

## Related

Steven Marygold's email to HarvDev/IUDev (2026-02-05) proposing FBcv gene group type simplification.