### PR TITLE
ci: build & push Docker image via GitHub Actions (replaces retired Docker Hub autobuild)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Extract metadata (tags, labels)
         id: meta

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and push Docker image
+
+# Replaces the retired Docker Hub Automated Build (the "Builds" tab / autobuild
+# webhook). Docker retired classic Automated Builds (full retirement 2027-04-01);
+# the autobuild link for this repo has lapsed, so GitHub pushes no longer rebuild
+# the image and it has been kept current by manual/GoCD pushes instead. This
+# workflow builds the root Dockerfile and pushes flybase/harvdev-peeves-parser to
+# Docker Hub on every push to master, exactly like the old autobuild did.
+#
+# Requires two repository secrets (Settings -> Secrets and variables -> Actions):
+#   DOCKERHUB_USERNAME  - a Docker Hub user that can push to flybase/*
+#   DOCKERHUB_TOKEN     - a Docker Hub access token (Account Settings -> Personal
+#                         access tokens) with Read & Write scope, NOT the password
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: flybase/harvdev-peeves-parser
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Why

Docker Hub retired classic **Automated Builds** (full retirement 2027-04-01).
This repo's autobuild link has lapsed: the autobuild trigger webhook is still
present but no longer rebuilds the image on push, so `flybase/harvdev-peeves-parser`
has been kept current by manual / GoCD (`harvdevgocd`) `docker push`es that don't
correspond to any GitHub commit. Same situation as harvdev-proforma-parser.

## What

Adds `.github/workflows/docker-publish.yml`, which reproduces the old autobuild:
on push to `master` (and `v*` tags) it builds the root `Dockerfile` and pushes
`flybase/harvdev-peeves-parser:latest` to Docker Hub.

## Required before merge — two repo secrets
Settings → Secrets and variables → Actions:
- `DOCKERHUB_USERNAME` — a Docker Hub user that can push to `flybase/*`
- `DOCKERHUB_TOKEN` — a Docker Hub **access token** (Read & Write), not the password

The workflow only triggers on push to `master`/tags, so this PR itself won't run
a build. Add the secrets, merge, then push to `master` (or use the Actions tab →
Run workflow) and the image builds automatically.

Note: this is a public repo. Repository secrets are not exposed to workflows
triggered by pull requests from forks, and this workflow only runs on push to
branches/tags in the repo itself, so the Docker Hub token is not exposed to PRs.
