### PR TITLE
v.2.92: Fixing bugs found by Claude

### DIFF
--- a/doc/VERSION
+++ b/doc/VERSION
@@ -1045,4 +1045,5 @@ our $Peeves_version = "2.89"; #  Update checks for AB8 (FTA-202)
 # 15.6.2026
 our $Peeves_version = "2.90"; #  Notes on origin (GA23a and GA23b) should not be filled in for transgenic (cassette) FBal (FTA-203)
 our $Peeves_version = "2.91"; #  GA12a should not be filled in for transgenic (cassette) FBal (FTA-204)
-
+# 16.6.2026
+our $Peeves_version = "2.92"; #  Fixing bugs found by Claude (correct variable in AB8 field, convert A23a checks and validate_GA23a to standard process_field_data)

--- a/doc/specs/allele/GA23a.txt
+++ b/doc/specs/allele/GA23a.txt
@@ -25,6 +25,9 @@ No (Implemented)
 
 ### Checks:
 
+
+Checks within field (validate_GA23a): 
+
 - 1 SoftCV prefix exists specifically for this field:
 Separable from:
 
@@ -49,7 +52,6 @@ Checks between fields:
 ### Status:
 
 
-
 ### Updated:
 
-gm260615.
+gm260616.

--- a/production/Peeves
+++ b/production/Peeves
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-our $Peeves_version = "2.91"; #  GA12a should not be filled in for transgenic (cassette) FBal (FTA-204)
+our $Peeves_version = "2.92"; #  Fixing bugs found by Claude (correct variable in AB8 field, convert A23a checks and validate_GA23a to standard process_field_data)
 
 =head2 Version
 
@@ -450,6 +450,7 @@ our %field_specific_checks = (
 	'GA13' => \&check_stamped_free_text,
 	'GA14' => \&no_stamps,
 
+	'GA23a' => \&validate_GA23a,
 
 # aberration proforma
 	'A1b' => \&validate_synonym_field,

--- a/production/allele.pl
+++ b/production/allele.pl
@@ -400,9 +400,7 @@ FIELD:
 	{
 		check_dups ($file, $2, $field, \%proforma_fields, \%dup_proforma_fields, $primary_symbol_list, $can_dup{$2} ? 1 : 0);
 		check_non_utf8 ($file, $2, $3);
-		unless (double_query ($file, $2, $3)) {
-			@GA23a_list =  validate_GA23a ($2, $1, $3);
-		}
+		@GA23a_list = process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '0');
 	}
 	elsif ($field =~ /^(.*?) (GA23b)\..*? :(.*)/s)
 	{
@@ -2167,51 +2165,43 @@ sub validate_GA10g ($$$)
 
 
 
-sub validate_GA23a ($$$)
-{
-# Notes on origin: must be preceded by a valid SoftCV prefix.  The following material is essentially a single
-# line of free text, for which we need only check material within stamps.
+sub validate_GA23a {
+# converted to process_field_data + %field_specific_checks format. 260616.
 
-    my ($code, $change, $n_o_o) = @_;
 
-    my @return_list;
-    changes ($file, $code, $change);		# Check for garbage, but otherwise don't worry about $change.
-    $n_o_o eq '' and return ();			# Absence of data is always acceptable.
+	my ($file, $code, $dehashed_data, $context) = @_;
 
-    foreach my $notes (dehash ($file, $code, $hash_entries, $n_o_o))
-    {
-	next if $notes eq '';						# Absence of data is always acceptable.
-	foreach my $note (split /\n/, $notes)
-	{
-	    $note = trim_space_from_ends ($file, $code, $note);
+	$dehashed_data eq '' and return;
 
-		push @return_list, $note;
-	    next if $note eq '';					# Ignore blank lines.
-	    my (undef, $softcv, $space, $rest) = ($note =~ /^((.*?):)?( )?(.*)/);
-	    if (defined $softcv)
-	    {
-		valid_symbol ($softcv, 'notes on origin') or report ($file, "%s: Invalid SoftCV prefix '%s' in '%s'",
-								     $code, $softcv, $note);
-		defined $space or report ($file, "%s: I think you omitted the space after the SoftCV prefix in '%s'",
-					  $code, $note);
+	my $uniqued_data = check_for_duplicated_lines($file,$code,$dehashed_data,$context->{$code});
 
-# Add temporary message that 'Associated with:' is not allowed - will eventually just remove
-# as allowed value from symtab.pl
-		if ($softcv eq 'Associated with') {
+	foreach my $note (keys %{$uniqued_data}) {
 
-			report ($file, "%s: 'Associated with:' is no longer an allowed SoftCV prefix - remove this line and any associated data in GA23b, and simply describe the nature of the mutation (including all genes affected) in the GA12b 'Nature of the lesion' field instead.\n!%s", $code, $proforma_fields{$code});
+		# insert field specific checks here
+		# Notes on origin: must be preceded by a valid SoftCV prefix.
+		# The rest of the line is essentially free text, so just check for symbol validity within stamps.
 
-		}
+		my (undef, $softcv, $space, $rest) = ($note =~ /^((.*?):)?( )?(.*)/);
+		if (defined $softcv) {
+			valid_symbol ($softcv, 'notes on origin') or report ($file, "%s: Invalid SoftCV prefix '%s' in '%s'",$code, $softcv, $note);
+			defined $space or report ($file, "%s: I think you omitted the space after the SoftCV prefix in '%s'",$code, $note);
+
+			# Add temporary message that 'Associated with:' is not allowed - will eventually just remove
+			# as allowed value from symtab.pl
+			if ($softcv eq 'Associated with') {
+
+				report ($file, "%s: 'Associated with:' is no longer an allowed SoftCV prefix - remove this line and any associated data in GA23b, and simply describe the nature of the mutation (including all genes affected) in the GA12b 'Nature of the lesion' field instead.\n!%s", $code, $context->{$code});
+
+			}
 		
-	    }
-	    else
-	    {
-		report ($file, "%s: Missing SoftCV prefix in '%s'", $code, $note);
-	    }
-	    check_stamps ($file, $code, trim_space_from_ends ($rest));
+		} else {
+			report ($file, "%s: Missing SoftCV prefix in '%s'", $code, $note);
+		}
+
+		check_stamps ($file, $code, $rest);
+	
 	}
-    }
-	return @return_list;
+
 }
 
 

--- a/production/balancer.pl
+++ b/production/balancer.pl
@@ -199,7 +199,7 @@ FIELD:
 	elsif ($field =~ /^(.*?) (AB8)\..*? :(.*)/s)
 	{
 	    check_dups ($file, $2, $field, \%proforma_fields, \%dummy_dup_proforma_fields, $primary_symbol_list, 0);
-		unless (changes ($file, $field, $1)) {
+		unless (changes ($file, $2, $1)) {
 			contains_data ($file, $2, $3, $proforma_fields{$2});
 		}
 		process_field_data ($file, $hash_entries, $1, '1', $2, $3, \%proforma_fields, '1');

--- a/records2test/FTA-203/gm2.edit
+++ b/records2test/FTA-203/gm2.edit
@@ -1,0 +1,78 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0223931
+! P2.   Parent multipub abbreviation               *w :Neuron
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Pph13
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Pph13[U6.NIG.sgRNA] # Pph13[UAS.ORF-CC]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :P{U6-Pph13.NIG.sgRNA} # M{UAS-Pph13.ORF-CC}
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct represents a human disease-implicated variant? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :
+! GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :??checking file with hashes in GA1a. no errors??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!

--- a/records2test/FTA-203/gm3.edit
+++ b/records2test/FTA-203/gm3.edit
@@ -1,0 +1,78 @@
+! PUBLICATION PROFORMA                   Version 48:  21 May 2018
+!
+! P22.  FlyBase reference ID (FBrf) or "new"  *U :FBrf0223931
+! P2.   Parent multipub abbreviation               *w :Neuron
+! P40.  Flag Cambridge for curation           CAMCUR :
+! P41.  Flag Harvard for curation            HARVCUR :
+! P42.  Flag Ontologists for curation           ONTO :
+! P43.  Flag Disease for curation            DISEASE :
+! P44.  Disease(s) relevant to FBrf      [free text] :
+! P19.  Internal notes                   *H :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! GENE DATA
+! Insert gene proforma below.
+! GENE PROFORMA                          Version 80:  6 Nov 2023
+!
+! G1a.  Gene symbol to use in FlyBase                       *a :Pph13
+! G1b.  Gene symbol(s) used in reference                    *i :
+! G1g.  Is G1a the current symbol of a gene in FlyBase? (y/n)  :y
+! G2b.  Gene name(s) used in reference                      *V :
+! G37.  Member of Gene Group (symbol) *G :
+! G34.  Antibody generated (monoclonal/polyclonal)      *s :
+! G15.  Internal notes  *W :
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ALLELE DATA FOR THIS GENE
+! Insert allele proforma(e) below.
+! ALLELE PROFORMA                        Version 65: 23 July 2021
+!
+! GA1a.  Allele symbol to use in FlyBase                        *A :Pph13[U6.NIG.sgRNA] # Pph13[UAS.ORF-CC]
+! GA1b.  Allele symbol(s) used in reference                     *i :
+! GA1e.  Action - rename this allele symbol                        :
+! GA1f.  Action - merge these alleles (symbols)                    :
+! GA1g.  Is GA1a the current symbol of an allele in FlyBase? (y/n) :y
+! GA2a.  Action - allele name to use in FlyBase                 *e :
+! GA2b.  Allele name(s) used in reference                       *V :
+! GA2c.  Action - rename this allele name                          :
+! GA31.  Etymology                                              *u :
+! GA4.   Allele class [CV]                                  *k :
+! GA10a. Associated construct                                *I :P{U6-Pph13.NIG.sgRNA} # M{UAS-Pph13.ORF-CC}
+! GA10b. Construct symbol(s) used in reference               *L :
+! GA10c. Associated insertion - G1a is outwith insert      *G :
+! GA10d. Insertion symbol(s) used in reference             *N :
+! GA10e. Associated insertion - G1a is inside insert    *G :
+! GA10f. Insertion symbol(s) used in reference          *N :
+! GA10g. Associated aberration / cytology normal (+)    *P/*C :
+! GA8.   Mutagen [CV]                                  *o :
+! GA36.  Allele/construct represents a human disease-implicated variant? (y or blank) :
+! GA11.  Progenitor genotype                           *O :
+! GA23a. Notes on origin [SoftCV]                      *R :Separable from: @a[symbol]@. # forgot_prefix
+! GA23b. Notes on origin [free text]                   *R :
+! GA35.  Transgenic product class [CV]     :
+! GA30e. Regulatory region(s) present (symbol)  :
+! GA12a. Nature of the lesion, wrt GA11 - nt/aa changes [SoftCV] *s :
+! GA12b. Nature of the lesion, wrt GA11 [free text]              *s :
+! GA30a. Tagged with experimental tool (FBto symbol)        :
+! GA30b. Other experimental tools carried (FBto symbol)     :
+! GA30c. Encoded experimental tool (FBto symbol)  :
+! GA30d. Encoded experimental tool [CV]           :
+! GA30f. Propagate uses from construct ? (n or blank)  :
+! GA13.  Miscellaneous comments                        *u :
+! GA20.  GA1a stated to be lost?                         *v :
+! GA14.  Internal notes  *W :??checking file with hashes in GA1a. errors as not supposed to fill in GA23b for construct alleles??
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next allele proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Insert next gene proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ABERRATION DATA
+! Insert aberration proforma below.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! TRANSPOSON INSERTION DATA
+! MOLECULAR SEGMENT AND CONSTRUCT DATA
+! NATURAL TRANSPOSON DATA
+! Insert relevant proforma(e) below.
+
+!!!!!!!!!!!!!!!!!! END OF RECORD FOR THIS PUBLICATION !!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
change to fix bugs found by Claude:

- change to balancer.pl corrects the variable used in the AB8 check so it is consistent with other fields

- as suggesteed by Claude, converted the `validate_A23a` subroutine so it can be used by `process_field_data` to fix a bug  - now the code populates the `@GA23a_list` hash correctly if a proforma with multiple GA1a is submitted.
   - added test records with multiple GA1a filled in to check the fix
   - also fixed a separate bug that was not reporting invalid symbols in the GA23a within field checks (changed `check_stamps ($file, $code, trim_space_from_ends ($rest));` to `check_stamps ($file, $code, $rest);`
